### PR TITLE
 Fix installation on Python 2.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Examples
 ::
 
   % ./vermin.py
-  Vermin 0.2.2
+  Vermin 0.2.3
   Usage: ./vermin.py [options] <python source files and folders..>
 
   Options:

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(here, "README.rst"), encoding="utf-8") as f:
 
 setup(
   name="vermin",
-  version="0.2.2",
+  version="0.2.3",
 
   description="Concurrently detect the minimum Python versions needed to run code",
   long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
 
   packages=find_packages(exclude=["tests"]),
 
-  python_requires=">=2.7, >=3",
+  python_requires=">=2.7",
 
   entry_points={
     "console_scripts": [

--- a/vermin/constants.py
+++ b/vermin/constants.py
@@ -1,1 +1,1 @@
-VERSION = "0.2.2"
+VERSION = "0.2.3"


### PR DESCRIPTION
pip appears to combine python_version clause with and, rather than or. Thus the following occurred

```
pip install vermin==0.2.2 -v
...
  Analyzing links from page https://pypi.python.org/simple/vermin/
    The package
https://pypi.python.org/packages/ba/40/75747303731b1447ea8b84691af2e0fe254b2e350ffdfdaa38b1c01a9791/vermin-0.2.2-py2.py3-none-any.whl#md5=d10bc6a57bf597528b73dbb187991eba
(from https://pypi.python.org/simple/vermin/) (requires-python:>=2.7,
>=3) is incompatible with the pythonversion in use. Acceptable python
versions are:>=2.7, >=3
  Could not find a version that satisfies the requirement vermin==0.2.2
(from versions: )
Cleaning up...
No matching distribution found for vermin==0.2.2
```