### PR TITLE
Take .pyw scripts into account

### DIFF
--- a/vermin/detection.py
+++ b/vermin/detection.py
@@ -26,7 +26,7 @@ def detect_paths(paths):
       except OSError as ex:
         nprint("Ignoring {}: {}".format(path, ex))
       continue
-    if not isfile(path) or not path.lower().endswith(".py"):
+    if not isfile(path) or (not path.lower().endswith(".py") and not path.lower().endswith(".pyw")):
       continue
     accept_paths.append(path)
   return accept_paths


### PR DESCRIPTION
Scripts with `.pyw` extension should also be taken into account in detection. They are used to suppress console window creation on Windows (which is useful for GUI programs), and also work as usual on Unix-like systems.

See:
https://docs.python.org/3/tutorial/appendix.html#executable-python-scripts
https://docs.python.org/3/using/windows.html#from-file-associations