### PR TITLE
Added hmac.digest from Python 3.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Concurrently detect the minimum Python versions needed to run code. Additionally
 vanilla Python, and it doesn't have any external dependencies, it works with v2.7+ and v3+.
 
 It functions by parsing Python code into an abstract syntax tree (AST), which it traverses and
-matches against internal dictionaries with 872 rules divided into 120 modules, 603
+matches against internal dictionaries with 872 rules divided into 120 modules, 604
 classes/functions/constants members of modules, 145 kwargs of functions, and 4 strftime directives.
 Including looking for v2/v3 ``print expr`` and ``print(expr)``, ``long``, f-strings, coroutines
 (``async`` and ``await``), boolean constants, ``"..".format(..)``, imports (``import X``, ``from X

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Concurrently detect the minimum Python versions needed to run code. Additionally
 vanilla Python, and it doesn't have any external dependencies, it works with v2.7+ and v3+.
 
 It functions by parsing Python code into an abstract syntax tree (AST), which it traverses and
-matches against internal dictionaries with 872 rules divided into 120 modules, 604
+matches against internal dictionaries with 873 rules divided into 120 modules, 604
 classes/functions/constants members of modules, 145 kwargs of functions, and 4 strftime directives.
 Including looking for v2/v3 ``print expr`` and ``print(expr)``, ``long``, f-strings, coroutines
 (``async`` and ``await``), boolean constants, ``"..".format(..)``, imports (``import X``, ``from X

--- a/tests/function.py
+++ b/tests/function.py
@@ -567,6 +567,9 @@ class VerminFunctionMemberTests(VerminTest):
   def test_compare_digest_from_hmac(self):
     self.assertOnlyIn((2.7, 3.3), detect("import hmac\nhmac.compare_digest()"))
 
+  def test_hmac_digest(self):
+    self.assertOnlyIn(3.7, detect("import hmac\nhmac.digest()"))
+
   def test_isgenerator_from_inspect(self):
     self.assertOnlyIn((2.6, 3.0), detect("import inspect\ninspect.isgenerator()"))
 

--- a/tests/module.py
+++ b/tests/module.py
@@ -242,9 +242,6 @@ class VerminModuleTests(VerminTest):
   def test_hmac(self):
     self.assertOnlyIn((2.2, 3.0), detect("import hmac"))
 
-  def test_hmac_digest(self):
-    self.assertOnlyIn(3.7, detect("import hmac.digest"))
-
   def test_hotshot(self):
     self.assertOnlyIn(2.2, detect("import hotshot"))
 

--- a/tests/module.py
+++ b/tests/module.py
@@ -242,6 +242,9 @@ class VerminModuleTests(VerminTest):
   def test_hmac(self):
     self.assertOnlyIn((2.2, 3.0), detect("import hmac"))
 
+  def test_hmac_digest(self):
+    self.assertOnlyIn(3.7, detect("import hmac.digest"))
+
   def test_hotshot(self):
     self.assertOnlyIn(2.2, detect("import hotshot"))
 

--- a/vermin/rules.py
+++ b/vermin/rules.py
@@ -339,6 +339,7 @@ MOD_MEM_REQS = {
   "heapq.nlargest": (2.4, 3.0),
   "heapq.nsmallest": (2.4, 3.0),
   "hmac.compare_digest": (2.7, 3.3),
+  "hmac.digest": (None, 3.7),
   "importlib.machinery.ExtensionFileLoader.create_module": (None, 3.5),
   "importlib.machinery.ExtensionFileLoader.exec_module": (None, 3.5),
   "importlib.machinery.ExtensionFileLoader.get_filename": (None, 3.4),


### PR DESCRIPTION
Greetings.

The `digest` function of the `hmac` module was added in version 3.7.

Ref: https://docs.python.org/3/library/hmac.html#hmac.digest