### PR TITLE
Add rule for str.format()

### DIFF
--- a/tests/builtin_functions.py
+++ b/tests/builtin_functions.py
@@ -146,6 +146,12 @@ class VerminBuiltinFunctionsMemberTests(VerminTest):
     self.assertOnlyIn(3.3, detect("s=str()\ns.casefold()"))
     self.assertOnlyIn(3.3, detect("str().casefold()"))
 
+  def test_format_of_str(self):
+    self.assertOnlyIn((2.6, 3.0), detect("s=\"\"\ns.format()"))
+    self.assertOnlyIn((2.6, 3.0), detect("\"\".format()"))
+    self.assertOnlyIn((2.6, 3.0), detect("s=str()\ns.format()"))
+    self.assertOnlyIn((2.6, 3.0), detect("str().format()"))
+
   def test_format_map_of_str(self):
     self.assertOnlyIn(3.2, detect("s=\"\"\ns.format_map()"))
     self.assertOnlyIn(3.2, detect("\"\".format_map()"))

--- a/vermin/rules.py
+++ b/vermin/rules.py
@@ -305,6 +305,7 @@ MOD_MEM_REQS = {
   "staticmethod": (2.2, 3.0),
   "str.casefold": (None, 3.3),
   "str.decode": (2.2, None),
+  "str.format": (2.6, 3.0),
   "str.format_map": (None, 3.2),
   "str.isascii": (None, 3.7),
   "str.isdecimal": (None, 3.0),


### PR DESCRIPTION
PEP 3101 for advanved string formatting was introduced with Python 3 and
has ben backported to 2.6.