### PR TITLE
Update csv.DictWriter.writeheader Rule

### DIFF
--- a/tests/function.py
+++ b/tests/function.py
@@ -1422,7 +1422,7 @@ class VerminFunctionMemberTests(VerminTest):
     self.assertOnlyIn((3, 7), detect("import contextlib\ncontextlib.nullcontext()"))
 
   def test_writeheader_of_csv_DictWriter(self):
-    self.assertOnlyIn((3, 2), detect("from csv import DictWriter\nDictWriter.writeheader()"))
+    self.assertOnlyIn(((2, 7), (3, 2)), detect("from csv import DictWriter\nDictWriter.writeheader()"))
 
   def test_update_lines_cols_of_curses(self):
     self.assertOnlyIn((3, 5), detect("import curses\ncurses.update_lines_cols()"))

--- a/tests/function.py
+++ b/tests/function.py
@@ -1422,7 +1422,8 @@ class VerminFunctionMemberTests(VerminTest):
     self.assertOnlyIn((3, 7), detect("import contextlib\ncontextlib.nullcontext()"))
 
   def test_writeheader_of_csv_DictWriter(self):
-    self.assertOnlyIn(((2, 7), (3, 2)), detect("from csv import DictWriter\nDictWriter.writeheader()"))
+    self.assertOnlyIn(((2, 7), (3, 2)), detect("from csv import DictWriter\n"
+                                               "DictWriter.writeheader()"))
 
   def test_update_lines_cols_of_curses(self):
     self.assertOnlyIn((3, 5), detect("import curses\ncurses.update_lines_cols()"))

--- a/vermin/rules.py
+++ b/vermin/rules.py
@@ -388,7 +388,7 @@ def MOD_MEM_REQS():
     "contextlib.suppress": (None, (3, 4)),
     "contextlib.suppress": (None, (3, 4)),
     "crypt.mksalt": (None, (3, 3)),
-    "csv.DictWriter.writeheader": (None, (3, 2)),
+    "csv.DictWriter.writeheader": ((2, 7), (3, 2)),
     "csv.field_size_limit": ((2, 5), (3, 0)),
     "ctypes._CData.from_buffer": ((2, 6), (3, 0)),
     "ctypes._CData.from_buffer_copy": ((2, 6), (3, 0)),


### PR DESCRIPTION
Based on the Python 2 docs I think this updated rule is more correct

https://docs.python.org/2/library/csv.html#csv.DictWriter.writeheader