### PR TITLE
Add minimum versions for function decorators and class decorators

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,8 +78,9 @@ variable annotations (also ``Final`` and ``Literal``), ``continue`` in ``finally
 inverse ``pow()``, array typecodes, codecs error handler names, encodings, ``%`` formatting and
 directives for bytes and bytearray, generalized unpacking, dictionary union (``{..} | {..}``),
 dictionary union merge (``a = {..}; a |= {..}``), builtin generic type annotations (``list[str]``),
-and relaxed decorators. It tries to detect and ignore user-defined functions, classes, arguments,
-and variables with names that clash with library-defined symbols.
+function decorators, class decorators and relaxed decorators. It tries to detect and ignore
+user-defined functions, classes, arguments, and variables with names that clash with library-defined
+symbols.
 
 Caveats
 =======

--- a/tests/lang.py
+++ b/tests/lang.py
@@ -1083,42 +1083,42 @@ collections.abc.Reversible[int]
     self.assertOnlyIn((3, 9), visitor.minimum_versions())
 
   def test_function_decorators(self):
-    visitor = visit("def foo(): pass")
+    visitor = self.visit("def foo(): pass")
     self.assertFalse(visitor.function_decorators())
 
-    visitor = visit("@f\ndef foo(): pass")
+    visitor = self.visit("@f\ndef foo(): pass")
     self.assertTrue(visitor.function_decorators())
     self.assertOnlyIn(((2, 4), (3, 0)), visitor.minimum_versions())
 
-    visitor = visit("@button_0.clicked.connect\ndef foo(): pass")
+    visitor = self.visit("@button_0.clicked.connect\ndef foo(): pass")
     self.assertTrue(visitor.function_decorators())
     self.assertOnlyIn(((2, 4), (3, 0)), visitor.minimum_versions())
 
-    visitor = visit("@eval('buttons[1].clicked.connect')\ndef foo(): pass")
+    visitor = self.visit("@eval('buttons[1].clicked.connect')\ndef foo(): pass")
     self.assertTrue(visitor.function_decorators())
     self.assertOnlyIn(((2, 4), (3, 0)), visitor.minimum_versions())
 
-    visitor = visit("@x.y(func)\ndef foo(): pass")
+    visitor = self.visit("@x.y(func)\ndef foo(): pass")
     self.assertTrue(visitor.function_decorators())
     self.assertOnlyIn(((2, 4), (3, 0)), visitor.minimum_versions())
 
   def test_class_decorators(self):
-    visitor = visit("class A: pass")
+    visitor = self.visit("class A: pass")
     self.assertFalse(visitor.class_decorators())
 
-    visitor = visit("@f\nclass A: pass")
+    visitor = self.visit("@f\nclass A: pass")
     self.assertTrue(visitor.class_decorators())
     self.assertOnlyIn(((2, 6), (3, 0)), visitor.minimum_versions())
 
-    visitor = visit("@button_0.clicked.connect\nclass A: pass")
+    visitor = self.visit("@button_0.clicked.connect\nclass A: pass")
     self.assertTrue(visitor.class_decorators())
     self.assertOnlyIn(((2, 6), (3, 0)), visitor.minimum_versions())
 
-    visitor = visit("@eval('buttons[1].clicked.connect')\nclass A: pass")
+    visitor = self.visit("@eval('buttons[1].clicked.connect')\nclass A: pass")
     self.assertTrue(visitor.class_decorators())
     self.assertOnlyIn(((2, 6), (3, 0)), visitor.minimum_versions())
 
-    visitor = visit("@x.y(func)\nclass A: pass")
+    visitor = self.visit("@x.y(func)\nclass A: pass")
     self.assertTrue(visitor.class_decorators())
     self.assertOnlyIn(((2, 6), (3, 0)), visitor.minimum_versions())
 

--- a/tests/lang.py
+++ b/tests/lang.py
@@ -1082,6 +1082,46 @@ collections.abc.Reversible[int]
     self.assertTrue(visitor.builtin_generic_type_annotations())
     self.assertOnlyIn((3, 9), visitor.minimum_versions())
 
+  def test_function_decorators(self):
+    visitor = visit("def foo(): pass")
+    self.assertFalse(visitor.function_decorators())
+
+    visitor = visit("@f\ndef foo(): pass")
+    self.assertTrue(visitor.function_decorators())
+    self.assertOnlyIn(((2, 4), (3, 0)), visitor.minimum_versions())
+
+    visitor = visit("@button_0.clicked.connect\ndef foo(): pass")
+    self.assertTrue(visitor.function_decorators())
+    self.assertOnlyIn(((2, 4), (3, 0)), visitor.minimum_versions())
+
+    visitor = visit("@eval('buttons[1].clicked.connect')\ndef foo(): pass")
+    self.assertTrue(visitor.function_decorators())
+    self.assertOnlyIn(((2, 4), (3, 0)), visitor.minimum_versions())
+
+    visitor = visit("@x.y(func)\ndef foo(): pass")
+    self.assertTrue(visitor.function_decorators())
+    self.assertOnlyIn(((2, 4), (3, 0)), visitor.minimum_versions())
+
+  def test_class_decorators(self):
+    visitor = visit("class A: pass")
+    self.assertFalse(visitor.class_decorators())
+
+    visitor = visit("@f\nclass A: pass")
+    self.assertTrue(visitor.class_decorators())
+    self.assertOnlyIn(((2, 6), (3, 0)), visitor.minimum_versions())
+
+    visitor = visit("@button_0.clicked.connect\nclass A: pass")
+    self.assertTrue(visitor.class_decorators())
+    self.assertOnlyIn(((2, 6), (3, 0)), visitor.minimum_versions())
+
+    visitor = visit("@eval('buttons[1].clicked.connect')\nclass A: pass")
+    self.assertTrue(visitor.class_decorators())
+    self.assertOnlyIn(((2, 6), (3, 0)), visitor.minimum_versions())
+
+    visitor = visit("@x.y(func)\nclass A: pass")
+    self.assertTrue(visitor.class_decorators())
+    self.assertOnlyIn(((2, 6), (3, 0)), visitor.minimum_versions())
+
   def test_relaxed_decorators(self):
     visitor = self.visit("@f\ndef foo(): pass")
     self.assertFalse(visitor.relaxed_decorators())

--- a/vermin/source_visitor.py
+++ b/vermin/source_visitor.py
@@ -380,10 +380,10 @@ class SourceVisitor(ast.NodeVisitor):
       mins = self.__add_versions_entity(mins, (None, (3, 9)), "builtin generic type annotations")
 
     if self.function_decorators():
-      mins = add_versions_entity(mins, ((2, 4), (3, 0)), "function decorators")
+      mins = self.__add_versions_entity(mins, ((2, 4), (3, 0)), "function decorators")
 
     if self.class_decorators():
-      mins = add_versions_entity(mins, ((2, 6), (3, 0)), "class decorators")
+      mins = self.__add_versions_entity(mins, ((2, 6), (3, 0)), "class decorators")
 
     if self.relaxed_decorators():
       mins = self.__add_versions_entity(mins, (None, (3, 9)), "relaxed decorators")

--- a/vermin/source_visitor.py
+++ b/vermin/source_visitor.py
@@ -71,6 +71,8 @@ class SourceVisitor(ast.NodeVisitor):
     self.__dict_union = False
     self.__dict_union_merge = False
     self.__builtin_generic_type_annotations = False
+    self.__function_decorators = False
+    self.__class_decorators = False
     self.__relaxed_decorators = False
     self.__builtin_types = {"dict", "set", "list", "unicode", "str", "int", "float", "long",
                             "bytes"}
@@ -240,6 +242,12 @@ class SourceVisitor(ast.NodeVisitor):
   def builtin_generic_type_annotations(self):
     return self.__builtin_generic_type_annotations
 
+  def function_decorators(self):
+    return self.__function_decorators
+
+  def class_decorators(self):
+    return self.__class_decorators
+
   def relaxed_decorators(self):
     return self.__relaxed_decorators
 
@@ -370,6 +378,12 @@ class SourceVisitor(ast.NodeVisitor):
 
     if self.builtin_generic_type_annotations():
       mins = self.__add_versions_entity(mins, (None, (3, 9)), "builtin generic type annotations")
+
+    if self.function_decorators():
+      mins = add_versions_entity(mins, ((2, 4), (3, 0)), "function decorators")
+
+    if self.class_decorators():
+      mins = add_versions_entity(mins, ((2, 6), (3, 0)), "class decorators")
 
     if self.relaxed_decorators():
       mins = self.__add_versions_entity(mins, (None, (3, 9)), "relaxed decorators")
@@ -1386,25 +1400,29 @@ ast.Call(func=ast.Name)."""
     # Checking for relaxed decorators, i.e. decorators that aren't a dotted name (name or attribute)
     # or a function call. `Load()` is also ignored since they occur all over the place for
     # non-relaxed decorators, too.
-    if hasattr(node, "decorator_list"):
-      for decorator in node.decorator_list:
-        if self.__is_no_line(decorator.lineno):
-          continue
-        # If decorator is a function call, then only look in the body branch, not arguments and
-        # such.
-        for n in ast.walk(decorator if not isinstance(decorator, ast.Call) else decorator.func):
-          if not (isinstance(n, ast.Name) or isinstance(n, ast.Attribute) or
-                  isinstance(n, ast.Load)):
-            self.__relaxed_decorators = True
-            self.__vvprint("relaxed decorators require 3.9+", line=decorator.lineno)
-            break
+    for decorator in node.decorator_list:
+      if self.__is_no_line(decorator.lineno):
+        continue
+      # If decorator is a function call, then only look in the body branch, not arguments and
+      # such.
+      for n in ast.walk(decorator if not isinstance(decorator, ast.Call) else decorator.func):
+        if not (isinstance(n, ast.Name) or isinstance(n, ast.Attribute) or
+                isinstance(n, ast.Load)):
+          self.__relaxed_decorators = True
+          self.__vvprint("relaxed decorators require 3.9+", line=decorator.lineno)
+          break
 
   def __handle_FunctionDef(self, node):
     if self.__is_no_line(node.lineno):
       return False
 
     self.__add_user_def(node.name)
-    self.__check_relaxed_decorators(node)
+
+    if getattr(node, "decorator_list", None):
+      self.__function_decorators = True
+      self.__vvprint("function decorators require 2.4+", line=node.lineno)
+      self.__check_relaxed_decorators(node)
+
     self.generic_visit(node)
 
     def has_ann():
@@ -1471,7 +1489,10 @@ ast.Call(func=ast.Name)."""
     if self.__is_no_line(node.lineno):
       return
     self.__add_user_def(node.name)
-    self.__check_relaxed_decorators(node)
+    if getattr(node, "decorator_list", None):
+      self.__class_decorators = True
+      self.__vvprint("class decorators require 2.6+", line=node.lineno)
+      self.__check_relaxed_decorators(node)
     self.generic_visit(node)
 
   def visit_NameConstant(self, node):


### PR DESCRIPTION
- Function decorators were introduced in Python 2.4
- Class decorators were introduced in Python 2.6/3.0