### PR TITLE
Fix exception cause related minimum versions

### DIFF
--- a/tests/lang.py
+++ b/tests/lang.py
@@ -547,10 +547,18 @@ class VerminLanguageTests(VerminTest):
     self.assertTrue(visitor.yield_from())
     self.assertOnlyIn((3, 3), visitor.minimum_versions())
 
-  @VerminTest.skipUnlessVersion(3, 3)
+  @VerminTest.skipUnlessVersion(3, 0)
   def test_raise_cause(self):
+    visitor = self.visit("raise Exception() from ValueError")
+    self.assertTrue(visitor.raise_cause())
+    self.assertFalse(visitor.raise_from_none())
+    self.assertOnlyIn((3, 0), visitor.minimum_versions())
+
+  @VerminTest.skipUnlessVersion(3, 3)
+  def test_raise_from_none(self):
     visitor = self.visit("raise Exception() from None")
     self.assertTrue(visitor.raise_cause())
+    self.assertTrue(visitor.raise_from_none())
     self.assertOnlyIn((3, 3), visitor.minimum_versions())
 
   def test_dict_comprehension(self):

--- a/vermin/source_visitor.py
+++ b/vermin/source_visitor.py
@@ -1552,20 +1552,22 @@ ast.Call(func=ast.Name)."""
     self.__seen_yield += 1
     self.generic_visit(node)
 
-  def __is_None_node(self, node):
-    if isinstance(node, ast.Name) and node.id == 'None':
-      return True
-    if hasattr(ast, 'NameConstant') and isinstance(node, ast.NameConstant) and node.value is None:
-      return True
-    if hasattr(ast, 'Constant') and isinstance(node, ast.Constant) and node.value is None:
-      return True
-    return False
-
   def visit_Raise(self, node):
     if hasattr(node, "cause") and node.cause is not None:
       self.__raise_cause = True
       self.__vvprint("exception cause", line=node.lineno, versions=[None, (3, 0)])
-      if self.__is_None_node(node.cause):
+
+      def is_None_node(node):
+        if isinstance(node, ast.Name) and node.id == 'None':
+          return True
+        if hasattr(ast, 'NameConstant') and isinstance(node, ast.NameConstant) and\
+           node.value is None:
+          return True
+        if hasattr(ast, 'Constant') and isinstance(node, ast.Constant) and node.value is None:
+          return True
+        return False
+
+      if is_None_node(node.cause):
         self.__raise_from_none = True
         self.__vvprint("raise ... from None", line=node.lineno, versions=[None, (3, 3)])
     seen_raise = self.__seen_raise

--- a/vermin/source_visitor.py
+++ b/vermin/source_visitor.py
@@ -23,6 +23,15 @@ def is_neg_int_node(node):
     (isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub) and
      isinstance(node.operand, ast.Num) and isinstance(node.operand.n, int))
 
+def is_none_node(node):
+  if isinstance(node, ast.Name) and node.id == 'None':
+    return True
+  if hasattr(ast, 'NameConstant') and isinstance(node, ast.NameConstant) and node.value is None:
+    return True
+  if hasattr(ast, 'Constant') and isinstance(node, ast.Constant) and node.value is None:
+    return True
+  return False
+
 def trim_fstring_value(value):  # pragma: no cover
   # HACK: Since parentheses are stripped of the AST, we'll just remove all those deduced or directly
   # available such that the self-doc f-strings can be compared.
@@ -1556,18 +1565,7 @@ ast.Call(func=ast.Name)."""
     if hasattr(node, "cause") and node.cause is not None:
       self.__raise_cause = True
       self.__vvprint("exception cause", line=node.lineno, versions=[None, (3, 0)])
-
-      def is_None_node(node):
-        if isinstance(node, ast.Name) and node.id == 'None':
-          return True
-        if hasattr(ast, 'NameConstant') and isinstance(node, ast.NameConstant) and\
-           node.value is None:
-          return True
-        if hasattr(ast, 'Constant') and isinstance(node, ast.Constant) and node.value is None:
-          return True
-        return False
-
-      if is_None_node(node.cause):
+      if is_none_node(node.cause):
         self.__raise_from_none = True
         self.__vvprint("raise ... from None", line=node.lineno, versions=[None, (3, 3)])
     seen_raise = self.__seen_raise


### PR DESCRIPTION
According to [PEP 3134](https://www.python.org/dev/peps/pep-3134/) and [PEP 409](https://www.python.org/dev/peps/pep-0409/), exception cause (`raise ... from ...`) is 3.0+, and in 3.3+ the cause is allowed to be `None`.