### PR TITLE
Revise PR #61

### DIFF
--- a/tests/class.py
+++ b/tests/class.py
@@ -134,8 +134,23 @@ class VerminClassMemberTests(VerminTest):
   def test_Collection_of_typing(self):
     self.assertOnlyIn((3, 6), self.detect("from typing import Collection"))
 
+  def test_ContextManager_of_typing(self):
+    self.assertOnlyIn((3, 5), self.detect("from typing import ContextManager"))
+    self.assertTrue(self.config.add_backport("typing"))
+    self.assertOnlyIn(((2, 7), (3, 3)), self.detect("from typing import ContextManager"))
+
   def test_Coroutine_of_typing(self):
     self.assertOnlyIn((3, 5), self.detect("from typing import Coroutine"))
+
+  def test_Counter_of_typing(self):
+    self.assertOnlyIn((3, 5), self.detect("from typing import Counter"))
+    self.assertTrue(self.config.add_backport("typing"))
+    self.assertOnlyIn(((2, 7), (3, 3)), self.detect("from typing import Counter"))
+
+  def test_Deque_of_typing(self):
+    self.assertOnlyIn((3, 5), self.detect("from typing import Deque"))
+    self.assertTrue(self.config.add_backport("typing"))
+    self.assertOnlyIn(((2, 7), (3, 3)), self.detect("from typing import Deque"))
 
   def test_OrderedDict_of_typing(self):
     self.assertOnlyIn((3, 7), self.detect("from typing import OrderedDict"))
@@ -156,10 +171,20 @@ class VerminClassMemberTests(VerminTest):
     self.assertTrue(self.config.add_backport("typing"))
     self.assertOnlyIn(((2, 7), (3, 8)), self.detect("from typing import Protocol"))
 
+  def test_SupportsBytes_of_typing(self):
+    self.assertOnlyIn((3, 5), self.detect("from typing import SupportsBytes"))
+    self.assertTrue(self.config.add_backport("typing"))
+    self.assertOnlyIn((3, 2), self.detect("from typing import SupportsBytes"))
+
   def test_SupportsIndex_of_typing(self):
     self.assertOnlyIn((3, 8), self.detect("from typing import SupportsIndex"))
     self.assertTrue(self.config.add_backport("typing"))
     self.assertOnlyIn(((2, 7), (3, 4)), self.detect("from typing import SupportsIndex"))
+
+  def test_SupportsRound_of_typing(self):
+    self.assertOnlyIn((3, 5), self.detect("from typing import SupportsRound"))
+    self.assertTrue(self.config.add_backport("typing"))
+    self.assertOnlyIn((3, 2), self.detect("from typing import SupportsRound"))
 
   def test_Awaitable_of_typing(self):
     self.assertOnlyIn((3, 5), self.detect("from typing import Awaitable"))

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -2639,6 +2639,11 @@ class VerminConstantMemberTests(VerminTest):
   def test_WrapperDescriptorType_of_types(self):
     self.assertOnlyIn((3, 7), self.detect("from types import WrapperDescriptorType"))
 
+  def test_NoReturn_of_typing(self):
+    self.assertOnlyIn((3, 5), self.detect("from typing import NoReturn"))
+    self.assertTrue(self.config.add_backport("typing"))
+    self.assertOnlyIn(((2, 7), (3, 3)), self.detect("from typing import NoReturn"))
+
   def test_Final_of_typing(self):
     self.assertOnlyIn((3, 8), self.detect("from typing import Final"))
     self.assertOnlyIn((3, 5), self.detect("""import typing

--- a/vermin/rules.py
+++ b/vermin/rules.py
@@ -313,15 +313,26 @@ def MOD_MEM_REQS(config):
     # Notes: `typing.ChainMap` relies on `collections.ChainMap`, which is 3.3+.
     "typing.ChainMap": (None, (3, 5) if not bp("typing", config) else (3, 3)),
     "typing.Collection": (None, (3, 6)),
+    # Notes:
+    #  `typing.ContextManager` was added in `typing` backport 3.6.2 (which requires 2.7 or 3.3+).
+    "typing.ContextManager": (None, (3, 5)) if not bp("typing", config) else ((2, 7), (3, 3)),
     "typing.Coroutine": (None, (3, 5)),
+    # Notes: `typing.Counter` was added in `typing` backport 3.6.1 (which requires 2.7 or 3.3+).
+    "typing.Counter": (None, (3, 5)) if not bp("typing", config) else ((2, 7), (3, 3)),
+    # Notes: `typing.Deque` was added in `typing` backport 3.6.1 (which requires 2.7 or 3.3+).
+    "typing.Deque": (None, (3, 5)) if not bp("typing", config) else ((2, 7), (3, 3)),
     "typing.OrderedDict": (None, (3, 7)),
     # Notes:
     #  `typing.Protocol` is backported to Python 2.7. For Python 3 it goes to `typing_extensions`.
     #  The same applies for some other rules below.
     "typing.Protocol": (None, (3, 8)) if not bp("typing", config) else ((2, 7), (3, 8)),
+    # Notes: `object.__bytes__` is 3.2+
+    "typing.SupportsBytes": (None, (3, 5)) if not bp("typing", config) else (None, (3, 2)),
     # Notes:
     #  `typing.SupportsIndex` was added in `typing` backport 3.7.4 (which requires 2.7 or 3.4+).
     "typing.SupportsIndex": (None, (3, 8)) if not bp("typing", config) else ((2, 7), (3, 4)),
+    # Notes: `object.__round__` is 3.0+
+    "typing.SupportsRound": (None, (3, 5)) if not bp("typing", config) else (None, (3, 2)),
     "typing.TypedDict": (None, (3, 8)) if not bp("typing", config) else ((2, 7), (3, 8)),
     "unittest.IsolatedAsyncioTestCase": (None, (3, 8)),
     "unittest.TextTestResult": ((2, 7), (3, 2)),
@@ -2329,6 +2340,8 @@ def MOD_MEM_REQS(config):
     "types.StringTypes": ((2, 2), None),
     "types.WrapperDescriptorType": (None, (3, 7)),
     "typing.Annotated": (None, (3, 9)),
+    # Notes: `typing.NoReturn` was added in `typing` backport 3.6.2 (which requires 2.7 or 3.3+).
+    "typing.NoReturn": (None, (3, 5)) if not bp("typing", config) else ((2, 7), (3, 3)),
     "typing.Final": (None, (3, 8)) if not bp("typing", config) else ((2, 7), (3, 8)),
     "typing.Literal": (None, (3, 8)) if not bp("typing", config) else ((2, 7), (3, 8)),
     "unicodedata.ucd_3_2_0": ((2, 3), (3, 0)),


### PR DESCRIPTION
When revising the `typing` rule to be 3.2+ last time in #61, I forgot to review two categories of rules:

- Rules deleted in the first commit (they might not be available in the `typing` backport before it dropped support for 3.2)
- Rules that are not present in `rules.py` (i.e. `typing` members which were available since the initial version of `typing` stdlib in 3.5.0, thus they don't have a "New in version ..." marker in the documentation, but they may not necessarily be backported to 2.7 and 3.2+)

So here are 6 more rules to be added.