### PR TITLE
Detect `nonlocal` and user-defined `long`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,17 +74,17 @@ Features
 Features detected include v2/v3 ``print expr`` and ``print(expr)``, ``long``, f-strings, coroutines
 (``async`` and ``await``), asynchronous generators (``await`` and ``yield`` in same function),
 asynchronous comprehensions, ``await`` in comprehensions, asynchronous ``for``-loops, boolean
-constants, named expressions, keyword-only parameters, positional-only parameters, ``yield from``,
-exception context cause (``raise .. from ..``), ``dict`` comprehensions, infix matrix
+constants, named expressions, keyword-only parameters, positional-only parameters, ``nonlocal``,
+``yield from``, exception context cause (``raise .. from ..``), ``dict`` comprehensions, infix matrix
 multiplication, ``"..".format(..)``, imports (``import X``, ``from X import Y``, ``from X import
 *``), function calls wrt. name and kwargs, ``strftime`` + ``strptime`` directives used, function and
 variable annotations (also ``Final`` and ``Literal``), ``continue`` in ``finally`` block, modular
 inverse ``pow()``, array typecodes, codecs error handler names, encodings, ``%`` formatting and
-directives for bytes and bytearray, generalized unpacking, dictionary union (``{..} | {..}``),
-dictionary union merge (``a = {..}; a |= {..}``), builtin generic type annotations (``list[str]``),
-function decorators, class decorators and relaxed decorators. It tries to detect and ignore
-user-defined functions, classes, arguments, and variables with names that clash with library-defined
-symbols.
+directives for bytes and bytearray, unpacking assignment, generalized unpacking, dictionary union
+(``{..} | {..}``), dictionary union merge (``a = {..}; a |= {..}``), builtin generic type
+annotations (``list[str]``), function decorators, class decorators and relaxed decorators. It tries
+to detect and ignore user-defined functions, classes, arguments, and variables with names that clash
+with library-defined symbols.
 
 Caveats
 =======

--- a/tests/lang.py
+++ b/tests/lang.py
@@ -541,6 +541,12 @@ class VerminLanguageTests(VerminTest):
     self.assertTrue(visitor.pos_only_args())
     self.assertOnlyIn((3, 8), visitor.minimum_versions())
 
+  @VerminTest.skipUnlessVersion(3)
+  def test_nonlocal_stmt(self):
+    visitor = self.visit("def foo():\n\tlong = 1\n\tdef bar():\n\t\tnonlocal long")
+    self.assertTrue(visitor.nonlocal_stmt())
+    self.assertOnlyIn((3, 0), visitor.minimum_versions())
+
   @VerminTest.skipUnlessVersion(3, 3)
   def test_yield_from(self):
     visitor = self.visit("def foo(x): yield from range(x)")


### PR DESCRIPTION
- Detect `nonlocal` as 3.0+ (see [PEP 3104](https://www.python.org/dev/peps/pep-3104/))
- Ignore `long` in `visit_Name` if it's user-defined