### PR TITLE
Detect ellipsis literal out of slices

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,11 +80,11 @@ multiplication, ``"..".format(..)``, imports (``import X``, ``from X import Y``,
 *``), function calls wrt. name and kwargs, ``strftime`` + ``strptime`` directives used, function and
 variable annotations (also ``Final`` and ``Literal``), ``continue`` in ``finally`` block, modular
 inverse ``pow()``, array typecodes, codecs error handler names, encodings, ``%`` formatting and
-directives for bytes and bytearray, unpacking assignment, generalized unpacking, dictionary union
-(``{..} | {..}``), dictionary union merge (``a = {..}; a |= {..}``), builtin generic type
-annotations (``list[str]``), function decorators, class decorators and relaxed decorators. It tries
-to detect and ignore user-defined functions, classes, arguments, and variables with names that clash
-with library-defined symbols.
+directives for bytes and bytearray, unpacking assignment, generalized unpacking, ellipsis literal
+(`...`) out of slices, dictionary union (``{..} | {..}``), dictionary union merge
+(``a = {..}; a |= {..}``), builtin generic type annotations (``list[str]``), function decorators,
+class decorators and relaxed decorators. It tries to detect and ignore user-defined functions,
+classes, arguments, and variables with names that clash with library-defined symbols.
 
 Caveats
 =======

--- a/tests/lang.py
+++ b/tests/lang.py
@@ -890,6 +890,25 @@ class VerminLanguageTests(VerminTest):
     self.assertFalse(visitor.generalized_unpacking(), msg=source)
     self.assertOnlyIn((3, 0), visitor.minimum_versions(), msg=source)
 
+  def test_ellipsis_in_slices(self):
+    visitor = self.visit('x[...]')
+    self.assertFalse(visitor.ellipsis_out_of_slices())
+    self.assertEqual([(0, 0), (0, 0)], visitor.minimum_versions())
+
+    visitor = self.visit('x[a, ..., b]')
+    self.assertFalse(visitor.ellipsis_out_of_slices())
+    self.assertEqual([(0, 0), (0, 0)], visitor.minimum_versions())
+
+  @VerminTest.skipUnlessVersion(3)
+  def test_ellipsis_out_of_slices(self):
+    visitor = self.visit('...')
+    self.assertTrue(visitor.ellipsis_out_of_slices())
+    self.assertOnlyIn((3, 0), visitor.minimum_versions())
+
+    visitor = self.visit('x[[...]]')
+    self.assertTrue(visitor.ellipsis_out_of_slices())
+    self.assertOnlyIn((3, 0), visitor.minimum_versions())
+
   @VerminTest.skipUnlessVersion(3, 5)
   def test_bytes_format(self):
     visitor = self.visit("b'%x' % 10")

--- a/vermin/source_visitor.py
+++ b/vermin/source_visitor.py
@@ -1238,10 +1238,7 @@ ast.Call(func=ast.Name)."""
 
     # From 3.8, Ellipsis() is represented as Constant(value=Ellipsis)
     if is_ellipsis_node(node):
-      # Force identity testing instead of equality testing.
-      if not any(n is node for n in self.__ellipsis_nodes_in_slices):
-        self.__ellipsis_out_of_slices = True
-        self.__vvprint("ellipsis literal (`...`) out of slices", versions=[None, (3, 0)])
+      self.visit_Ellipsis(node)
 
   def __extract_fstring_value(self, node):  # pragma: no cover
     value = []


### PR DESCRIPTION
Ellipsis literal (`...`) can only be used for slices before Python 3.0. Since 3.0 they can be used anywhere.