### PR TITLE
Detect multiple context expressions in a `with` statement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,12 +80,12 @@ comprehensions, ``dict`` comprehensions, infix matrix multiplication, ``"..".for
 (``import X``, ``from X import Y``, ``from X import *``), function calls wrt. name and kwargs,
 ``strftime`` + ``strptime`` directives used, function and variable annotations (also ``Final`` and
 ``Literal``), ``continue`` in ``finally`` block, modular inverse ``pow()``, array typecodes, codecs
-error handler names, encodings, ``%`` formatting and directives for bytes and bytearray, unpacking
-assignment, generalized unpacking, ellipsis literal (`...`) out of slices, dictionary union
-(``{..} | {..}``), dictionary union merge (``a = {..}; a |= {..}``), builtin generic type
-annotations (``list[str]``), function decorators, class decorators and relaxed decorators. It tries
-to detect and ignore user-defined functions, classes, arguments, and variables with names that clash
-with library-defined symbols.
+error handler names, encodings, ``%`` formatting and directives for bytes and bytearray, ``with``
+statement, multiple context expressions in a ``with`` statement, unpacking assignment, generalized
+unpacking, ellipsis literal (`...`) out of slices, dictionary union (``{..} | {..}``), dictionary
+union merge (``a = {..}; a |= {..}``), builtin generic type annotations (``list[str]``), function
+decorators, class decorators and relaxed decorators. It tries to detect and ignore user-defined
+functions, classes, arguments, and variables with names that clash with library-defined symbols.
 
 Caveats
 =======

--- a/tests/lang.py
+++ b/tests/lang.py
@@ -653,8 +653,6 @@ class VerminLanguageTests(VerminTest):
 
   @VerminTest.parameterized_args([
     ["with func():\n  pass"],
-    ["with (a, b): pass"],
-    ["with (a, b) as c: pass"],
     ["with a as (b, c): pass"],
     ["with a as b:\n\twith c as d:\n\t\tpass"],
   ])


### PR DESCRIPTION
Multiple context expressions in a `with` statement is 2.7+, 3.1+.