### PR TITLE
Add support for pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,4 +3,5 @@
   description: checks the minimum needed Python version to run your package
   entry: vermin -vv
   language: python
+  require_serial: true
   types: [python]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,16 +1,16 @@
 - id: vermin
   name: Check minimum Python version
-  description: Checks the minimum needed Python version to run your package. Only runs on staged files (your target must be `x.y-` rather than `x.y` for it to work properly).
+  description: Checks the minimum needed Python version to run your package. Only runs on staged files (your target must be `x.y-` rather than `x.y` for it to work properly). If using non-default args, including `--violations` is recommended.
   entry: vermin
-  args: ["-vv"]
+  args: ["--violations"]
   require_serial: true
   language: python
   types: [python]
 - id: vermin-all
   name: Check minimum Python version
-  description: Checks the minimum needed Python version to run your package. Runs on all Python files in the repo.
+  description: Checks the minimum needed Python version to run your package. Runs on all Python files in the repo. If using non-default args, including `--violations` is recommended.
   entry: vermin
-  args: ["-vv", "."]
+  args: ["--violations", "."]
   pass_filenames: false
   require_serial: true
   language: python

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: vermin
+  name: vermin
+  description: checks the minimum needed Python version to run your package
+  entry: vermin -vv
+  language: python
+  types: [python]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,17 @@
 - id: vermin
-  name: vermin
-  description: checks the minimum needed Python version to run your package
-  entry: vermin -vv
-  language: python
+  name: Check minimum Python version
+  description: Checks the minimum needed Python version to run your package. Only runs on staged files (your target must be `x.y-` rather than `x.y` for it to work properly).
+  entry: vermin
+  args: ["-vv"]
   require_serial: true
+  language: python
+  types: [python]
+- id: vermin-all
+  name: Check minimum Python version
+  description: Checks the minimum needed Python version to run your package. Runs on all Python files in the repo.
+  entry: vermin
+  args: ["-vv", "."]
+  pass_filenames: false
+  require_serial: true
+  language: python
   types: [python]

--- a/README.rst
+++ b/README.rst
@@ -81,21 +81,21 @@ Vermin can also be used as a `pre-commit <https://pre-commit.com/>`__ hook:
 
   repos:
     - repo: https://github.com/netromdk/vermin
-      rev: GIT_SHA_OR_TAG  # ex: `e88bda9` or `v1.3.4`
+      rev: GIT_SHA_OR_TAG  # ex: 'e88bda9' or 'v1.3.4'
       hooks:
         - id: vermin
           # specify your target version here, OR in a Vermin config file as usual:
           args: ['-t=3.8-', '--violations']
-          # (if your target is specified in a Vermin config, you may omit the `args` entry entirely)
+          # (if your target is specified in a Vermin config, you may omit the 'args' entry entirely)
 
 When using the hook, a target version must be specified via a Vermin config file in your package,
 or via the ``args`` option in your ``.pre-commit-config.yaml`` config. If you're passing the target
 via ``args``, it's recommended to also include ``--violations`` (shown above).
 
-If you're using the `vermin-all` hook, you can specify any target as you usually would. However, if
-you're using the `vermin` hook, your target must be in the form of `x.y-` (as opposed to `x.y`),
-otherwise you will run into issues when your staged changes meet a minimum version that is lower
-than your target.
+If you're using the ``vermin-all`` hook, you can specify any target as you usually would. However,
+if you're using the ``vermin`` hook, your target must be in the form of ``x.y-`` (as opposed to
+``x.y``), otherwise you will run into issues when your staged changes meet a minimum version that
+is lower than your target.
 
 See the `pre-commit docs <https://pre-commit.com/#quick-start>`__ for further general information
 on how to get hooks set up on your project.

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,22 @@ be used to check that the minimum required versions didn't change. The following
   script:
   - vermin -t=2.7 -t=3 project_package otherfile.py
 
+Vermin can also be used as a `pre-commit <https://pre-commit.com/>`__ hook:
+
+.. code-block:: yaml
+
+  repos:
+    - repo: https://github.com/netromdk/vermin
+      rev: e88bda9
+      hooks:
+        - id: vermin
+          # specify your target version here, OR in a Vermin config file as usual:
+          args: ['-t=3.8']
+
+When using the hook, a target version must be specified via a Vermin config file in your package,
+or via the ``args`` option in your ``.pre-commit-config.yaml`` config (shown above). For further
+information on setting up pre-commit for your project, see the `pre-commit docs <https://pre-commit.com/#quick-start>`__.
+
 Features
 ========
 

--- a/README.rst
+++ b/README.rst
@@ -81,15 +81,24 @@ Vermin can also be used as a `pre-commit <https://pre-commit.com/>`__ hook:
 
   repos:
     - repo: https://github.com/netromdk/vermin
-      rev: e88bda9
+      rev: GIT_SHA_OR_TAG  # ex: `e88bda9` or `v1.3.4`
       hooks:
         - id: vermin
           # specify your target version here, OR in a Vermin config file as usual:
-          args: ['-t=3.8']
+          args: ['-t=3.8-', '--violations']
+          # (if your target is specified in a Vermin config, you may omit the `args` entry entirely)
 
 When using the hook, a target version must be specified via a Vermin config file in your package,
-or via the ``args`` option in your ``.pre-commit-config.yaml`` config (shown above). For further
-information on setting up pre-commit for your project, see the `pre-commit docs <https://pre-commit.com/#quick-start>`__.
+or via the ``args`` option in your ``.pre-commit-config.yaml`` config. If you're passing the target
+via ``args``, it's recommended to also include ``--violations`` (shown above).
+
+If you're using the `vermin-all` hook, you can specify any target as you usually would. However, if
+you're using the `vermin` hook, your target must be in the form of `x.y-` (as opposed to `x.y`),
+otherwise you will run into issues when your staged changes meet a minimum version that is lower
+than your target.
+
+See the `pre-commit docs <https://pre-commit.com/#quick-start>`__ for further general information
+on how to get hooks set up on your project.
 
 Features
 ========


### PR DESCRIPTION
This allows you to use Vermin as a [pre-commit](https://pre-commit.com/) hook. The only setup required (outside of the normal pre-commit setup steps) is setting a target version for Vermin, which can either be set in a Vermin config file in your package, or directly via the `args` option in the `.pre-commit-config.yaml` (example shown in the README).

The `rev` value in the example hook configuration in the README should be set to the next git tag (likely `v1.3.4`?) when that release is made, and updated whenever a new version is released.