### PR TITLE
Vermin 1.6 will end support for py2.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Vermin
 Concurrently detect the minimum Python versions needed to run code. Additionally, since the code is
 vanilla Python, and it doesn't have any external dependencies, it works with v2.7+ and v3+.
 
-*Note: Vermin 1.5 will end support for running via Python 2.7* which has been `sunset
+*Note: Vermin 1.6 will end support for running via Python 2.7* which has been `sunset
 <https://www.python.org/doc/sunset-python-2/>`__ since January 1, 2020. Python 3.x is going to be
 required but detection of 2.x functionality will remain functional.
 


### PR DESCRIPTION
That means that Python 3.x will be required for running Vermin, but detection of Python 2.x
functionality will still remain.