### PR TITLE
Union types detection turned into opt-in feature

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -163,6 +163,12 @@ distinguish ``f'{a=}'`` from ``f'a={a}'``, for instance, since it optimizes some
 code as using fstring self-doc when only using general fstring. To enable (unstable) fstring
 self-doc detection, use ``--feature fstring-self-doc``.
 
+Detecting union types (``X | Y`` `PEP 604 <https://www.python.org/dev/peps/pep-0604/>`__) can be
+tricky because Vermin doesn't know all underlying details of constants and types since it parses and
+traverses the AST. For this reason, heuristics are employed and this can sometimes yield incorrect
+results (`#103 <https://github.com/netromdk/vermin/issues/103>`__). To enable (unstable) union types
+detection, use ``--feature union-types``.
+
 Function and variable annotations aren't evaluated at definition time when ``from __future__ import
 annotations`` is used (`PEP 563 <https://www.python.org/dev/peps/pep-0563/>`__). This is why
 ``--no-eval-annotations`` is on by default (since v1.1.1, `#66

--- a/vermin/features.py
+++ b/vermin/features.py
@@ -5,6 +5,10 @@ FEATURES = (
     "[Unstable] Detect self-documenting fstrings. Can in",
     "some cases wrongly report fstrings as self-documenting."
   ]),
+  ("union-types", [
+    "[Unstable] Detect union types `X | Y`. Can in some cases",
+    "wrongly report union types due to having to employ heuristics."
+  ]),
 )
 
 class Features:

--- a/vermin/source_visitor.py
+++ b/vermin/source_visitor.py
@@ -193,6 +193,10 @@ class SourceVisitor(ast.NodeVisitor):
     # incorrectly marks some source code as using fstring self-doc when only using general fstring.
     self.__fstring_self_doc_enabled = self.__config.has_feature("fstring-self-doc")
 
+    # Default to disabling union types detection because it sometimes fails to report it correctly
+    # due to using heuristics.
+    self.__union_types_enabled = self.__config.has_feature("union-types")
+
     # Used for incompatible versions texts.
     self.__info_versions = {}
 
@@ -1396,7 +1400,7 @@ ast.Call(func=ast.Name)."""
         return name is not None and \
           ((name not in self.__name_res and name not in self.__user_defs) or
            (name in self.__name_res_type))
-      if is_none_or_name(node.left) and is_none_or_name(node.right):
+      if self.__union_types_enabled and is_none_or_name(node.left) and is_none_or_name(node.right):
         self.__union_types = True
         self.__vvprint("union types as `X | Y`", line=node.lineno, versions=[None, (3, 10)],
                        plural=True)
@@ -1710,7 +1714,7 @@ ast.Call(func=ast.Name)."""
       # AugAssign(target=Name(id='a', ctx=Store()),
       #           op=BitOr(),
       #           value=Name(id='int', ctx=Load()))
-      elif is_union_type(node.target) and is_union_type(node.value):
+      elif self.__union_types_enabled and is_union_type(node.target) and is_union_type(node.value):
         self.__union_types = True
         self.__vvprint("union types as `a = X; a |= Y`", line=node.lineno, versions=[None, (3, 10)],
                        plural=True)


### PR DESCRIPTION
Detecting union types (``X | Y``) can be tricky because Vermin doesn't know all underlying details
of constants and types since it parses and traverses the AST. For this reason, heuristics are
employed and this can sometimes yield incorrect results.

- Union types detection turned into opt-in feature: `--feature union-types`
- Added caveat section to Readme

Relates to #103.