### PR TITLE
Add GitHub annotation output format

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -440,6 +440,12 @@ The GitHub output format has the same output as `parsable <#parsable-output>`__,
 formatted as GitHub Actions annotations. This let's you see minimum version violations as annotated
 errors directly from a GitHub pipeline.
 
+For annotations to appear in a pull request:
+
+- Vermin must be called from a GitHub Actions workflow triggered by a PR
+- Vermin must be called with current working directory as the root of the repository
+- Only violations found in files changed in the PR will show up
+
 Contributing
 ============
 

--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,7 @@ Table of Contents
 * `API (experimental) <#api-experimental>`__
 * `Analysis Exclusions <#analysis-exclusions>`__
 * `Parsable Output <#parsable-output>`__
+* `GitHub Output <#github-output>`__
 * `Contributing <#contributing>`__
 
 Usage
@@ -431,6 +432,13 @@ That means that the final result is ``!2`` and ``3.4``, which is shown by the la
 .. code-block::
 
   :::!2:3.4:
+
+GitHub Output
+=============
+
+The GitHub output format has the same output as `parsable <#parsable-output>`__, but the lines are
+formatted as GitHub Actions annotations. This let's you see minimum version violations as annotated
+errors directly from a GitHub pipeline.
 
 Contributing
 ============

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(here, "README.rst"), encoding="utf-8") as f:
 
 setup(
   name="vermin",
-  version="1.6.0",
+  version="1.7.0",
 
   description="Concurrently detect the minimum Python versions needed to run code",
   long_description=long_description,

--- a/tests/arguments.py
+++ b/tests/arguments.py
@@ -337,22 +337,23 @@ aaa
       self.assertContainsDict({"code": 0}, self.parse_args(["--format", fmt]))
       self.assertEqual(fmt, self.config.format().name())
 
-    # Parsable verbose level 3, no tips, ignore incompatible versions, no `--versions`.
-    for args in (["--format", "parsable"], ["--format", "parsable", "--verbose"],
-                 ["--format", "parsable", "--versions"]):
+    for fmt in ("parsable", "github"):
+      # Parsable verbose level 3, no tips, ignore incompatible versions, no `--versions`.
+      for args in (["--format", fmt], ["--format", fmt, "--verbose"],
+                  ["--format", fmt, "--versions"]):
+        self.config.reset()
+        self.assertContainsDict({"code": 0, "versions": False}, self.parse_args(args))
+        self.assertEqual(3, self.config.verbose())
+        self.assertTrue(self.config.ignore_incomp())
+        self.assertFalse(self.config.show_tips())
+
+      # Verbosity can be higher for parsable
       self.config.reset()
-      self.assertContainsDict({"code": 0, "versions": False}, self.parse_args(args))
-      self.assertEqual(3, self.config.verbose())
+      self.assertContainsDict({"code": 0, "versions": False},
+                              self.parse_args(["--format", fmt, "-vvvv"]))
+      self.assertEqual(4, self.config.verbose())
       self.assertTrue(self.config.ignore_incomp())
       self.assertFalse(self.config.show_tips())
-
-    # Verbosity can be higher for parsable.
-    self.config.reset()
-    self.assertContainsDict({"code": 0, "versions": False},
-                            self.parse_args(["--format", "parsable", "-vvvv"]))
-    self.assertEqual(4, self.config.verbose())
-    self.assertTrue(self.config.ignore_incomp())
-    self.assertFalse(self.config.show_tips())
 
   def test_pessimistic(self):
     self.assertFalse(self.config.pessimistic())

--- a/tests/general.py
+++ b/tests/general.py
@@ -100,15 +100,15 @@ c = 3
 """
 
     visitor = self.visit(src)
-    self.assertEqual(visitor.output_text(), """::error file=<unknown>,line=2,col=7,title=Requires Python 2.6, 3.0::'abc' module
-::error file=<unknown>,line=5,col=9,title=Requires Python !2, 3.9::'zoneinfo' module
-::error file=<unknown>,line=6,col=9,title=Requires Python 2.7, 3.2::'argparse' module
+    self.assertEqual(visitor.output_text(), """::error file=<unknown>,line=2,col=7,title=Requires Python 2.6%2C 3.0::'abc' module
+::error file=<unknown>,line=5,col=9,title=Requires Python !2%2C 3.9::'zoneinfo' module
+::error file=<unknown>,line=6,col=9,title=Requires Python 2.7%2C 3.2::'argparse' module
 """)
 
     visitor = self.visit(src, path="test.py")
-    self.assertEqual(visitor.output_text(), """::error file=test.py,line=2,col=7,title=Requires Python 2.6, 3.0::'abc' module
-::error file=test.py,line=5,col=9,title=Requires Python !2, 3.9::'zoneinfo' module
-::error file=test.py,line=6,col=9,title=Requires Python 2.7, 3.2::'argparse' module
+    self.assertEqual(visitor.output_text(), """::error file=test.py,line=2,col=7,title=Requires Python 2.6%2C 3.0::'abc' module
+::error file=test.py,line=5,col=9,title=Requires Python !2%2C 3.9::'zoneinfo' module
+::error file=test.py,line=6,col=9,title=Requires Python 2.7%2C 3.2::'argparse' module
 """)
 
     # subclasses ParsableFormat, so should also reject these paths

--- a/tests/lang.py
+++ b/tests/lang.py
@@ -11,7 +11,7 @@ class VerminLanguageTests(VerminTest):
 
     source = "print 'hello'"
     parser = Parser(source)
-    (node, mins, _novermin) = parser.detect(self.config)
+    (node, mins, _novermin, _err_msg) = parser.detect(self.config)
     v = current_version()
     if v >= (3, 4):
       self.assertEqual(node, None)

--- a/vermin/arguments.py
+++ b/vermin/arguments.py
@@ -4,6 +4,7 @@ import os
 from .constants import VERSION, DEFAULT_PROCESSES, CONFIG_FILE_NAMES, PROJECT_BOUNDARIES
 from .backports import Backports
 from .features import Features
+from .formats import ParsableFormat
 from .config import Config
 from .printing import nprint
 from . import formats
@@ -415,7 +416,7 @@ class Arguments:
       print("Cannot use quiet and verbose modes together!")
       return {"code": 1}
 
-    parsable = config.format().name() == "parsable"
+    parsable = isinstance(config.format(), ParsableFormat)
     if parsable:
       versions = False
 

--- a/vermin/formats/__init__.py
+++ b/vermin/formats/__init__.py
@@ -1,6 +1,7 @@
 from .format import Format
 from .default_format import DefaultFormat
 from .parsable_format import ParsableFormat
+from .github_format import GitHubFormat
 from ..utility import format_title_descs
 
 FORMATS = (
@@ -11,7 +12,13 @@ FORMATS = (
     "minimum py2 and py3 versions. Minimum verbosity level is set to",
     "3 but can be increased. Tips, hints, incompatible versions, and",
     "`--versions` are disabled. File paths containing ':' are ignored."
-  ])
+  ]),
+  ("github", [
+    "Same as parsable format, but each result is formatted as a GitHub",
+    "Actions annotation. This is intended to be used for checking"
+    "violations in a GitHub Actions pipeline, with annotations marked"
+    "as errors."
+  ]),
 )
 
 def names():
@@ -22,6 +29,8 @@ def from_name(name):
     return DefaultFormat()
   if name == "parsable":
     return ParsableFormat()
+  if name == "github":
+    return GitHubFormat()
   return None
 
 def help_str(indent=0):
@@ -31,6 +40,7 @@ __all__ = [
   "DefaultFormat",
   "Format",
   "ParsableFormat",
+  "GitHubFormat",
   "from_name",
   "help_str",
   "names",

--- a/vermin/formats/__init__.py
+++ b/vermin/formats/__init__.py
@@ -16,7 +16,7 @@ FORMATS = (
   ("github", [
     "Same as parsable format, but each result is formatted as a GitHub",
     "Actions annotation. Minimum version messages are annotated as",
-    "errors, and all other verbose messages as notices. The intent is"
+    "errors, and all other verbose messages as notices. The intent is",
     "that it be used for linting in a GitHub Actions pipeline."
   ]),
 )

--- a/vermin/formats/__init__.py
+++ b/vermin/formats/__init__.py
@@ -15,9 +15,9 @@ FORMATS = (
   ]),
   ("github", [
     "Same as parsable format, but each result is formatted as a GitHub",
-    "Actions annotation. This is intended to be used for checking"
-    "violations in a GitHub Actions pipeline, with annotations marked"
-    "as errors."
+    "Actions annotation. Minimum version messages are annotated as",
+    "errors, and all other verbose messages as notices. The intent is"
+    "that it be used for linting in a GitHub Actions pipeline."
   ]),
 )
 

--- a/vermin/formats/github_format.py
+++ b/vermin/formats/github_format.py
@@ -1,0 +1,65 @@
+from ..utility import bounded_str_hash, version_strings
+from .parsable_format import ParsableFormat
+
+
+class GitHubFormat(ParsableFormat):
+    """Variant of ParsableFormat which outputs as Github Actions annotations."""
+
+    def __init__(self, name="github"):
+        super().__init__(name)
+        self.order = {}
+        """cache sort order of lines; SourceVisitor maintains an internal list of outputs from
+		format_output_line; these are later dedulicated in a set, then passed to sort_output_lines;
+		so caching their order uses minimal extra memory and avoids a fragile parse of the already
+		serialized data to extract its sort order
+		"""
+
+    def format_output_line(self, msg, path=None, line=None, col=None, versions=None, plural=None):
+        # default title is for generic analysis errors/notices
+        title = "Python version requirement analysis"
+        level = "error"
+        if versions is None:
+            # indicates verbosity 4+
+            level = "notice"
+        else:
+            versions = version_strings(versions)
+            title = "Requires Python {}".format(versions)
+        if msg is None:
+            if versions is None:
+                msg = "user-defined symbols being ignored"
+            # msg is None when providing a summary
+            elif path is None:
+                msg = "Minimum Python version required across all files: {}".format(versions)
+            else:
+                msg = "Minimum Python version required for this file: {}".format(versions)
+        else:
+            msg = msg.replace("\n", "\\n")
+        vals = {
+            "file": path,
+            "line": line,
+            "col": col,
+            "title": title,
+        }
+        args = ",".join("{}={}".format(k, v) for k, v in vals.items() if v is not None)
+        out = "::{} {}::{}".format(level, args, msg)
+
+        # pre-calculate sort order
+        order = (line or 0) + (float(col or 0) + bounded_str_hash(title + "\n" + msg)) / 1000
+        self.order[out] = order
+        return out
+
+    def _sort_key(self, line):
+        """Uses cached order, falling back to plain hash if not found."""
+        if line not in self.order:
+            return bounded_str_hash(line)
+        return self.order[line]
+
+    def sort_output_lines(self, lines):
+        lines.sort(key=self._sort_key)
+        # SourceVisitor, which calls this, overwrites its internal list of outputs; so the input
+        # lines will never be reused; safe to clear the cache here. Only deleting the lines we've
+        # seen, to handle depth-first AST traversals.
+        for line in lines:
+            if line in self.order:
+                del self.order[line]
+        return lines

--- a/vermin/formats/github_format.py
+++ b/vermin/formats/github_format.py
@@ -1,5 +1,5 @@
+import os
 import re
-from pathlib import Path
 
 from ..utility import bounded_str_hash, version_strings
 from .parsable_format import ParsableFormat
@@ -21,10 +21,10 @@ class GitHubFormat(ParsableFormat):
         self.order = {}
         """cache sort order of lines; SourceVisitor maintains an internal list of outputs from
 		format_output_line; these are later dedulicated in a set, then passed to sort_output_lines;
-		so caching their order uses minimal extra memory and avoids a fragile parse of the already
+        so caching their order uses minimal extra memory and avoids a fragile parse of the already
 		serialized data to extract its sort order
 		"""
-        self.cwd = Path.cwd()
+        self.cwd = os.getcwd()
         """current working directory, to relativize paths"""
 
     def format_output_line(self, msg, path=None, line=None, col=None, versions=None, plural=None):
@@ -51,8 +51,8 @@ class GitHubFormat(ParsableFormat):
         # relativize path so github can link to it in a PR
         if path is not None:
             try:
-                path = Path(path).resolve()
-                path = path.relative_to(self.cwd)
+                path = os.path.abspath(path)
+                path = os.path.relpath(path, self.cwd)
             except ValueError:
                 pass
         vals = {

--- a/vermin/formats/github_format.py
+++ b/vermin/formats/github_format.py
@@ -3,7 +3,8 @@ from .parsable_format import ParsableFormat
 
 def escape(value):
     """Escape special characters in GitHub Actions annotations."""
-    return (value
+    return (
+        str(value)
         .replace('%', '%25') # must be first
         .replace(',', '%2C')
         .replace(':', '%3A')

--- a/vermin/formats/parsable_format.py
+++ b/vermin/formats/parsable_format.py
@@ -4,8 +4,8 @@ from .format import Format
 from ..utility import version_strings, sort_line_column_parsable
 
 class ParsableFormat(Format):
-  def __init__(self):
-    super().__init__("parsable")
+  def __init__(self, name="parsable"):
+    super().__init__(name)
 
   def set_config(self, config):
     config.set_verbose(max(3, config.verbose()))

--- a/vermin/main.py
+++ b/vermin/main.py
@@ -3,6 +3,7 @@ from os.path import abspath
 from copy import deepcopy
 
 from .config import Config
+from .formats import ParsableFormat
 from .printing import nprint, vprint
 from .detection import detect_paths
 from .processor import Processor
@@ -22,7 +23,7 @@ def main():
     sys.exit(args["code"])  # pragma: no cover
 
   paths = args["paths"]
-  parsable = config.format().name() == "parsable"
+  parsable = isinstance(config.format(), ParsableFormat)
 
   # Detect paths, remove duplicates, and sort for deterministic results.
   if not parsable:

--- a/vermin/parser.py
+++ b/vermin/parser.py
@@ -73,34 +73,33 @@ class Parser:
     assert config is not None
     try:
       (node, novermin) = self.parse(config.parse_comments())
-      return (node, [], novermin)
+      return (node, [], novermin, None)
     except SyntaxError as err:
+      def format_error(msg, versions):
+        """Generate a __vvprint message, as would be deone by the SourceVisitor."""
+        nonlocal err
+        return config.format().format_output_line(
+          msg, path=err.filename, line=err.lineno, col=err.offset, versions=versions)
+
       text = err.text.strip() if err.text is not None else ""
       lmsg = err.msg.lower()  # pylint: disable=no-member
-      parsable = config.format().name() == "parsable"
-      if parsable:  # pragma: no cover
-        text = text.replace("\n", "\\n")
 
       # `print expr` is a Python 2 construct, in v3 it's `print(expr)`.
       # NOTE: This is only triggered when running a python 3 on v2 code!
       if lmsg.find("missing parentheses in call to 'print'") != -1:
-        versions = "2.0:!3:" if parsable else ""
-        vvprint("{}:{}:{}:{}info: `{}` requires 2.0".
-                format(err.filename, err.lineno, err.offset, versions, text), config)
-        return (None, [(2, 0), None], set())
+        msg = "info: `{}` requires 2.0".format(text)
+        versions = [(2, 0), None]
+        return (None, versions, set(), format_error(msg, versions))
 
       # Type alias statements.
       # NOTE: This is only triggered with Python 3.11 or older.
       if lmsg == "invalid syntax" and TYPE_ALIAS_STMT.match(text) is not None:
-        versions = "!2:3.12:" if parsable else ""
-        vvprint("{}:{}:{}:{}info: type alias statement `{}` requires !2, 3.12".
-                format(err.filename, err.lineno, err.offset, versions, text), config)
-        return (None, [None, (3, 12)], set())
+        msg = "info: type alias statement `{}` requires !2, 3.12".format(text)
+        versions = [None, (3, 12)]
+        return (None, versions, set(), format_error(msg, versions))
 
       min_versions = [(0, 0), (0, 0)]
       if config.pessimistic():
         min_versions[sys.version_info.major - 2] = None
-      versions = version_strings(min_versions, separator=":") + ":" if parsable else ""
-      vvprint("{}:{}:{}:{}error: {}: {}".
-              format(err.filename, err.lineno, err.offset, versions, err.msg, text), config)
-    return (None, min_versions, set())
+      msg = "error: {}: {}".format(err.msg, text)
+      return (None, min_versions, set(), format_error(msg, min_versions))

--- a/vermin/processor.py
+++ b/vermin/processor.py
@@ -103,11 +103,12 @@ class Processor:
     res = ProcessResult(path)
 
     source = None
+    err_msg = None
     try:
       with open(path, mode="rb") as fp:
         source = fp.read()
         parser = Parser(source, path)
-        (res.node, res.mins, res.novermin) = parser.detect(config)
+        (res.node, res.mins, res.novermin, err_msg) = parser.detect(config)
     except KeyboardInterrupt:  # pragma: no cover
       return res
 
@@ -120,29 +121,32 @@ class Processor:
       return None
 
     except Exception as ex:  # pragma: no cover
-      res.text = "{}: {}, {}".format(path, type(ex), ex)
+      res.text = config.format().format_output_line("{}, {}".format(type(ex), ex), path=path)
       res.mins = [(0, 0), (0, 0)]
-
-    if res.node is None:
-      return res
 
     visitor = SourceVisitor(config, path, source)
     visitor.set_no_lines(res.novermin)
+    if err_msg is not None:
+      visitor.add_error_message(err_msg)
+
+    # node is None if there was a syntax error; we don't process the AST, but we keep all other
+    # logic so that it logs the syntax exception in the appropriate format
+    if res.node is not None:
+      try:
+        visitor.tour(res.node)
+      except KeyboardInterrupt:  # pragma: no cover
+        return res
 
     try:
-      visitor.tour(res.node)
-    except KeyboardInterrupt:  # pragma: no cover
-      return res
-
-    try:
-      res.mins = visitor.minimum_versions()
+      if res.node is not None:
+        res.mins = visitor.minimum_versions()
+        for m in visitor.modules():
+          if Backports.is_backport(m):
+            res.bps.add(m)
+        res.maybe_annotations = visitor.maybe_annotations()
       res.text = visitor.output_text()
-      for m in visitor.modules():
-        if Backports.is_backport(m):
-          res.bps.add(m)
-      res.maybe_annotations = visitor.maybe_annotations()
     except InvalidVersionException as ex:
       res.mins = None
-      res.text = str(ex)
+      res.text = config.format().format_output_line(str(ex), path=path)
 
     return res

--- a/vermin/source_state.py
+++ b/vermin/source_state.py
@@ -2,6 +2,7 @@ import sys
 import os
 from collections import deque
 
+from .formats import ParsableFormat
 from .rules import MOD_REQS, MOD_MEM_REQS, KWARGS_REQS
 
 class SourceState:
@@ -10,7 +11,7 @@ class SourceState:
   def __init__(self, config, path=None, source=None):
     assert config is not None, "Config must be specified!"
     self.config = config
-    self.parsable = config.format().name() == "parsable"
+    self.parsable = isinstance(config.format(), ParsableFormat)
 
     self.path = "<unknown>" if path is None else path
 

--- a/vermin/source_visitor.py
+++ b/vermin/source_visitor.py
@@ -564,6 +564,10 @@ class SourceVisitor(ast.NodeVisitor):
       text += "\n"
     return text
 
+  def add_error_message(self, line):
+    """Manually add an error message line to the output text."""
+    self.__s.output_text.append(line)
+
   def set_no_lines(self, lines):
     self.__no_lines = lines
 


### PR DESCRIPTION
This adds a `github` format option. It uses `parsable` format as a base, but the formatting is changed to write as a GitHub action annotation.

Secondly, SyntaxError's in `parser.py` were previously hardcoded to `parsable` format. While that may have made sense when there were just two formats, with the addition of a third format it doesn't. I've changed it to use the config format, and send the error message to the `SourceVisitor` to be included in its result text. I'm attaching it to `SourceVisitor` to be consistent, as that is how it is done for all non-SyntaxError exceptions. SyntaxError's will show up as GitHub action annotations as well, like we want, and they are handled like other exceptions would be printed for `default` / `parsable` formats.