### PR TITLE
fix(source_visitor): solve deprecated ast nodes to be removed in Python 3.14

### DIFF
--- a/vermin/source_visitor.py
+++ b/vermin/source_visitor.py
@@ -853,6 +853,17 @@ class SourceVisitor(ast.NodeVisitor):
     elif isinstance(node.value, ast.List):
       value_name = "list"
 
+    # If rvalue is None
+    elif sys.version_info >= (3, 8) and \
+         isinstance(node.value, ast.Constant) and node.value.value is None:
+      type_name = "None"
+    elif ((3, 8) > sys.version_info >= (3, 4)) and \
+         isinstance(node.value, ast.NameConstant) and node.value.value is None:
+      type_name = "None"
+    elif ((3, 4) > sys.version_info) and \
+         isinstance(node.value, ast.Name) and node.value.id == "None":
+      type_name = "None"
+
     # When a type name is used, and not a type instance.
     elif isinstance(node.value, ast.Name):
       type_name = node.value.id
@@ -868,8 +879,6 @@ class SourceVisitor(ast.NodeVisitor):
           value_name = "float"
         elif isinstance(v, bytes):
           value_name = "bytes"
-        elif v is None:
-          type_name = "None"
     else:
       if isinstance(node.value, ast.Str):
         value_name = "str"


### PR DESCRIPTION
This PR changes the following:
- Replace `ast.Str`, `ast.Bytes`, `ast.Num`, `ast.Ellipsis`, `ast.NameConstant` with `ast.Constant` w.r.t Python version
- Replace get value property `n` and `s` with `value`
- Remove checks to `ast.Index`. We used to run `node.slice.value` to get the underlying node. Starting from Python 3.9, `node.slice` gets the node directly

I have run `make test` and passed all tests.

However, I got a question about line 863~886 in the proposed code.
Comparing with the original code, I found that `None` is checked only if `ast` has `Constant`, which means it's checked on Python >= 3.8 only. I would like to know whether this is intended.

Resolves #297