### PR TITLE
Avoid false violations for unversioned backport sentinel (#330)

### DIFF
--- a/tests/violations.py
+++ b/tests/violations.py
@@ -270,6 +270,18 @@ import argparse    # 2.3, 3.1
     visitor = self.visit(code)
     self.assertEmpty(visitor.output_text())
 
+  def test_typing_extensions_no_violation_for_3x(self):
+    # `typing_extensions` with unversioned backport defaults to `((0,0),(0,0))` sentinel. Do not
+    # treat as a violation when targeting any Python 3.x.
+    self.config.add_target((3, 8))
+    visitor = self.visit("import typing_extensions")
+    self.assertEmpty(visitor.output_text())
+
+    self.config.clear_targets()
+    self.config.add_target((3, 7))
+    visitor = self.visit("import typing_extensions")
+    self.assertEmpty(visitor.output_text())
+
   def test_violate_unpacking_assignment(self):
     # Violation.
     self.config.add_target((2, 7))

--- a/vermin/source_visitor.py
+++ b/vermin/source_visitor.py
@@ -306,6 +306,9 @@ class SourceVisitor(ast.NodeVisitor):
     # versions none indicates verbose message, not that no compatible versions found
     if versions is None:
       return False
+    # If all version entries are sentinels or `None`, no real constraints exist.
+    if all(v is None or v == (0, 0) for v in versions):
+      return False
     # compare_requirements considers violation if no targets, which we don't want
     targets = self.__s.config.targets()
     if not targets:


### PR DESCRIPTION
`typing_extensions` without `--backport` uses a `((0, 0), (0, 0))` sentinel for "no version constraint". `__is_violation` now recognises this and does not report it as a violation when targeting any Python version.

Fixes #330.