### PR TITLE
Proper detection of self-doc and PEP 701 f-strings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,26 +137,26 @@ Features
 ========
 
 Features detected include v2/v3 ``print expr`` and ``print(expr)``, ``long``, f-strings,
-self-documenting f-strings (``f'{a=}'``), PEP 701 f-strings (3.12+), coroutines (``async`` and
-``await``), asynchronous generators (``await`` and ``yield`` in same function), asynchronous
-comprehensions, ``await`` in comprehensions, asynchronous ``for``-loops, boolean constants, named
-expressions, keyword-only parameters, positional-only parameters, ``nonlocal``, ``yield from``,
-exception context cause (``raise .. from ..``), ``except*``, ``set`` literals, ``set``
-comprehensions, ``dict`` comprehensions, infix matrix multiplication, ``"..".format(..)``, imports
-(``import X``, ``from X import Y``, ``from X import *``), function calls wrt. name and kwargs,
-``strftime`` + ``strptime`` directives used, function and variable annotations (also ``Final`` and
-``Literal``), ``continue`` in ``finally`` block, modular inverse ``pow()``, array typecodes, codecs
-error handler names, encodings, ``%`` formatting and directives for bytes and bytearray, ``with``
-statement, asynchronous ``with`` statement, multiple context expressions in a ``with`` statement,
-multiple context expressions in a ``with`` statement grouped with parenthesis, unpacking assignment,
-generalized unpacking, ellipsis literal (``...``) out of slices, dictionary union (``{..}  |
-{..}``), dictionary union merge (``a = {..}; a |= {..}``), builtin generic type annotations
-(``list[str]``), function decorators, class decorators, relaxed decorators, ``metaclass`` class
-keyword, pattern matching with ``match``, union types written as ``X | Y``, type alias statements
-(``type X = SomeType``), type alias statements with lambdas/comprehensions in class scopes, generic
-classes (``class C[T]: ...``), and template string literals (``t'{var}'``). It tries to detect and
-ignore user-defined functions, classes, arguments, and variables with names that clash with
-library-defined symbols.
+self-documenting f-strings (``f'{a=}'``), PEP 701 f-strings (3.12+), ``await`` in f-strings,
+coroutines (``async`` and ``await``), asynchronous generators (``await`` and ``yield`` in same
+function), asynchronous comprehensions, ``await`` in comprehensions, asynchronous ``for``-loops,
+boolean constants, named expressions, keyword-only parameters, positional-only parameters,
+``nonlocal``, ``yield from``, exception context cause (``raise .. from ..``), ``except*``, ``set``
+literals, ``set`` comprehensions, ``dict`` comprehensions, infix matrix multiplication,
+``"..".format(..)``, imports (``import X``, ``from X import Y``, ``from X import *``), function
+calls wrt. name and kwargs, ``strftime`` + ``strptime`` directives used, function and variable
+annotations (also ``Final`` and ``Literal``), ``continue`` in ``finally`` block, modular inverse
+``pow()``, array typecodes, codecs error handler names, encodings, ``%`` formatting and directives
+for bytes and bytearray, ``with`` statement, asynchronous ``with`` statement, multiple context
+expressions in a ``with`` statement, multiple context expressions in a ``with`` statement grouped
+with parenthesis, unpacking assignment, generalized unpacking, ellipsis literal (``...``) out of
+slices, dictionary union (``{..}  | {..}``), dictionary union merge (``a = {..}; a |= {..}``),
+builtin generic type annotations (``list[str]``), function decorators, class decorators, relaxed
+decorators, ``metaclass`` class keyword, pattern matching with ``match``, union types written as ``X
+| Y``, type alias statements (``type X = SomeType``), type alias statements with
+lambdas/comprehensions in class scopes, generic classes (``class C[T]: ...``), and template string
+literals (``t'{var}'``). It tries to detect and ignore user-defined functions, classes, arguments,
+and variables with names that clash with library-defined symbols.
 
 Caveats
 =======

--- a/README.rst
+++ b/README.rst
@@ -136,26 +136,27 @@ on how to get hooks set up on your project.
 Features
 ========
 
-Features detected include v2/v3 ``print expr`` and ``print(expr)``, ``long``, f-strings, coroutines
-(``async`` and ``await``), asynchronous generators (``await`` and ``yield`` in same function),
-asynchronous comprehensions, ``await`` in comprehensions, asynchronous ``for``-loops, boolean
-constants, named expressions, keyword-only parameters, positional-only parameters, ``nonlocal``,
-``yield from``, exception context cause (``raise .. from ..``), ``except*``, ``set`` literals,
-``set`` comprehensions, ``dict`` comprehensions, infix matrix multiplication, ``"..".format(..)``,
-imports (``import X``, ``from X import Y``, ``from X import *``), function calls wrt. name and
-kwargs, ``strftime`` + ``strptime`` directives used, function and variable annotations (also
-``Final`` and ``Literal``), ``continue`` in ``finally`` block, modular inverse ``pow()``, array
-typecodes, codecs error handler names, encodings, ``%`` formatting and directives for bytes and
-bytearray, ``with`` statement, asynchronous ``with`` statement, multiple context expressions in a
-``with`` statement, multiple context expressions in a ``with`` statement grouped with parenthesis,
-unpacking assignment, generalized unpacking, ellipsis literal (``...``) out of slices, dictionary
-union (``{..}  | {..}``), dictionary union merge (``a = {..}; a |= {..}``), builtin generic type
-annotations (``list[str]``), function decorators, class decorators, relaxed decorators,
-``metaclass`` class keyword, pattern matching with ``match``, union types written as ``X | Y``, type
-alias statements (``type X = SomeType``), type alias statements with lambdas/comprehensions in class
-scopes, generic classes (``class C[T]: ...``), and template string literals (``t'{var}'``). It tries
-to detect and ignore user-defined functions, classes, arguments, and variables with names that clash
-with library-defined symbols.
+Features detected include v2/v3 ``print expr`` and ``print(expr)``, ``long``, f-strings,
+self-documenting f-strings (``f'{a=}'``), PEP 701 f-strings (3.12+), coroutines (``async`` and
+``await``), asynchronous generators (``await`` and ``yield`` in same function), asynchronous
+comprehensions, ``await`` in comprehensions, asynchronous ``for``-loops, boolean constants, named
+expressions, keyword-only parameters, positional-only parameters, ``nonlocal``, ``yield from``,
+exception context cause (``raise .. from ..``), ``except*``, ``set`` literals, ``set``
+comprehensions, ``dict`` comprehensions, infix matrix multiplication, ``"..".format(..)``, imports
+(``import X``, ``from X import Y``, ``from X import *``), function calls wrt. name and kwargs,
+``strftime`` + ``strptime`` directives used, function and variable annotations (also ``Final`` and
+``Literal``), ``continue`` in ``finally`` block, modular inverse ``pow()``, array typecodes, codecs
+error handler names, encodings, ``%`` formatting and directives for bytes and bytearray, ``with``
+statement, asynchronous ``with`` statement, multiple context expressions in a ``with`` statement,
+multiple context expressions in a ``with`` statement grouped with parenthesis, unpacking assignment,
+generalized unpacking, ellipsis literal (``...``) out of slices, dictionary union (``{..}  |
+{..}``), dictionary union merge (``a = {..}; a |= {..}``), builtin generic type annotations
+(``list[str]``), function decorators, class decorators, relaxed decorators, ``metaclass`` class
+keyword, pattern matching with ``match``, union types written as ``X | Y``, type alias statements
+(``type X = SomeType``), type alias statements with lambdas/comprehensions in class scopes, generic
+classes (``class C[T]: ...``), and template string literals (``t'{var}'``). It tries to detect and
+ignore user-defined functions, classes, arguments, and variables with names that clash with
+library-defined symbols.
 
 Caveats
 =======
@@ -163,11 +164,16 @@ Caveats
 For frequently asked questions, check out the `FAQ discussions
 <https://github.com/netromdk/vermin/discussions/categories/faq>`__.
 
-Self-documenting fstrings detection has been disabled by default because the built-in AST cannot
-distinguish ``f'{a=}'`` from ``f'a={a}'``, for instance, since it optimizes some information away
-(`#39 <https://github.com/netromdk/vermin/issues/39>`__). And this incorrectly marks some source
-code as using fstring self-doc when only using general fstring. To enable (unstable) fstring
-self-doc detection, use ``--feature fstring-self-doc``.
+Self-documenting f-strings (``f'{a=}'``) cannot be distinguished from plain f-strings such as
+``f'a={a}'`` by the AST alone, because the parser optimizes some information away (`#39
+<https://github.com/netromdk/vermin/issues/39>`__). Vermin therefore also verifies against the
+source code. This detection is enabled by default, but can be disabled with ``--no-feature``. Note
+that this also disables all other features.
+
+PEP 701 f-string features require Python 3.12+. Vermin detects these using AST analysis combined
+with source code heuristics, enabled by default, which requires Vermin to parse the syntax on Python
+3.12+ (`#264 <https://github.com/netromdk/vermin/issues/264>`__). Use ``--no-feature`` to disable
+this detection.
 
 Detecting union types (``X | Y`` `PEP 604 <https://www.python.org/dev/peps/pep-0604/>`__) can be
 tricky because Vermin doesn't know all underlying details of constants and types since it parses and

--- a/runtests.py
+++ b/runtests.py
@@ -13,6 +13,7 @@ if ISOLATE is not None:
 
 SUITES = (
   "general",
+  "utility",
   "config",
   "arguments",
   "lang",

--- a/runtests.py
+++ b/runtests.py
@@ -17,6 +17,7 @@ SUITES = (
   "config",
   "arguments",
   "lang",
+  "fstring_detector",
   "module",
   "builtin_classes",
   "class",

--- a/sample.vermin.ini
+++ b/sample.vermin.ini
@@ -115,7 +115,8 @@
 #  argparse
 
 ### Features ###
-# Some features are disabled by default due to being unstable but can be enabled explicitly.
+# fstring-self-doc and fstring-pep701 are enabled by default. Other features must be enabled
+# explicitly. Use `--no-feature` to disable all features.
 #
 # Get full list via `--help`.
 #

--- a/tests/arguments.py
+++ b/tests/arguments.py
@@ -304,18 +304,31 @@ aaa
     self.assertFalse(self.config.show_tips())
 
   def test_feature(self):
+    # Default features are enabled.
+    self.config.reset()
+    self.assertContainsDict({"code": 0}, self.parse_args(["--verbose"]))
+    self.assertEqualItems(Features.defaults(), self.config.features())
+
+    # `--feature` is additive on top of the default features.
+    self.config.reset()
+    self.assertContainsDict({"code": 0}, self.parse_args(["--feature", "union-types"]))
+    feats = Features.defaults() | {"union-types"}
+    self.assertEqualItems(feats, self.config.features())
+
     # Needs <name> part.
+    self.config.reset()
     self.assertContainsDict({"code": 1}, self.parse_args(["--feature"]))
-    self.assertEmpty(self.config.features())
+    self.assertEqualItems(Features.defaults(), self.config.features())
 
     # Unknown feature.
+    self.config.reset()
     self.assertContainsDict({"code": 1}, self.parse_args(["--feature", "foobarbaz"]))
-    self.assertEmpty(self.config.features())
+    self.assertEqualItems(Features.defaults(), self.config.features())
 
-    # Known features.
+    # Known features can be enabled individually after clearing all defaults.
     for feature in Features.features():
       self.config.reset()
-      self.assertContainsDict({"code": 0}, self.parse_args(["--feature", feature]))
+      self.assertContainsDict({"code": 0}, self.parse_args(["--no-feature", "--feature", feature]))
       self.assertEqualItems([feature], self.config.features())
       self.assertContainsDict({"code": 0}, self.parse_args(["--no-feature"]))
       self.assertEmpty(self.config.features())

--- a/tests/config.py
+++ b/tests/config.py
@@ -20,7 +20,7 @@ class VerminConfigTests(VerminTest):
     self.assertFalse(self.config.analyze_hidden())
     self.assertEmpty(self.config.exclusions())
     self.assertEmpty(self.config.backports())
-    self.assertEmpty(self.config.features())
+    self.assertEqualItems(Features.defaults(), self.config.features())
     self.assertEmpty(self.config.targets())
     self.assertEqual("default", self.config.format().name())
     self.assertFalse(self.config.eval_annotations())

--- a/tests/exclusions.py
+++ b/tests/exclusions.py
@@ -19,6 +19,27 @@ class VerminExclusionsTests(VerminTest):
     visitor = self.visit("from argparse import ArgumentParser\nArgumentParser(allow_abbrev=False)")
     self.assertEqual([(0, 0), (0, 0)], visitor.minimum_versions())
 
+  @VerminTest.skipUnlessVersion(3, 8)
+  def test_kwarg_excluded_value(self):
+    self.config.enable_feature("fstring-self-doc")
+
+    source = "from argparse import ArgumentParser\nArgumentParser(allow_abbrev=f'{1=}')"
+    visitor = self.visit(source)
+    self.assertTrue(visitor.fstrings_self_doc())
+    self.assertEqual([("argparse.ArgumentParser", "allow_abbrev")], visitor.kwargs())
+    self.assertEqual([None, (3, 8)], visitor.minimum_versions())
+
+    self.config.add_exclusion("argparse.ArgumentParser(allow_abbrev)")
+    visitor = self.visit(source)
+    self.assertFalse(visitor.fstrings_self_doc())
+    self.assertEqual([], visitor.kwargs())
+    self.assertEqual([(2, 7), (3, 2)], visitor.minimum_versions())
+
+    self.config.add_exclusion("argparse")
+    visitor = self.visit(source)
+    self.assertFalse(visitor.fstrings_self_doc())
+    self.assertEqual([(0, 0), (0, 0)], visitor.minimum_versions())
+
   def test_codecs_error_handler(self):
     visitor = self.visit("import codecs\ncodecs.encode('test', 'utf-8', 'surrogateescape')")
     self.assertEqual([None, (3, 1)], visitor.minimum_versions())

--- a/tests/fstring_detector.py
+++ b/tests/fstring_detector.py
@@ -182,6 +182,37 @@ class FStringDetectorTests(VerminTest):
 
   @VerminTest.skipUnlessVersion(3, 12)
   @VerminTest.parameterized_args([
+    ('f"abc {a["x"]} def"', "same_quote_string"),
+    ("f'ab {a['x']} cd'", "same_quote_string"),
+    ('f"{d["k"]=}"', "same_quote_string"),
+    ('f"{ {"a": k} }"', "same_quote_string"),
+    ('f"t{ ["a"] }"', "same_quote_string"),
+    ('f"{a["x"]["y"]}"', "same_quote_string"),
+    ('f"{x:{"ab"}}"', "same_quote_string"),
+    ('f"{x:{w["y"]}}"', "same_quote_string"),
+    ("f'{ {'k': v} }'", "same_quote_string"),
+
+    # A different quote is valid since 3.6.
+    ('f"abc {a[\'x\']} def"', None),
+    ("f'abc {a[\"x\"]} def'", None),
+    ('f"{x:{w[\'y\']}}"', None),
+    ('f"{x:>a\'b}"', None),
+    ("f'{x:{w[\"y\"]}}'", None),
+
+    # Triple-quoted f-strings allow the single-character reuse natively.
+    ('f"""abc {a["x"]} def"""', None),
+    ('f"""abc {a[\'x\']} def"""', None),
+    ("f'''abc {a['x']} def'''", None),
+
+    ('f"{chr(34)}"', None),
+    ('f"{x:10}"', None),
+    ('f"{f\'x\'}"', None),
+  ])
+  def test_pep701_same_quote_string(self, source, expected):
+    self.assert_pep701(source, expected)
+
+  @VerminTest.skipUnlessVersion(3, 12)
+  @VerminTest.parameterized_args([
     ("f\"{'\\n'.join(x)}\"", "backslash"),
     ("f\"{r'\\n'}\"", "backslash"),
     ("f\"{'\\''}\"", "backslash"),

--- a/tests/fstring_detector.py
+++ b/tests/fstring_detector.py
@@ -73,6 +73,11 @@ class FStringDetectorTests(VerminTest):
     ("f'''{\n3\n=}'''", True),
     ("f'{f(a=4)=}'", True),
     ("f\"\\N{EXCLAMATION MARK}{a=}\"", True),
+    ("f\"{x = :.2f}\"", True),
+    ("f\"{(x) = :.2f}\"", True),
+    ("f\"{     2      +     2    =    }\"", True),
+    ("f\"{''=}\"", True),
+    ('f"""{1=: "this" is fine}"""', True),
 
     # CRLFs must not shift the byte offsets of nodes on later lines.
     ("x = 1\r\ns = f\"{x=}\"\r\n", True),

--- a/tests/fstring_detector.py
+++ b/tests/fstring_detector.py
@@ -90,6 +90,13 @@ class FStringDetectorTests(VerminTest):
     ("x = 1\rs = f\"{x=}\"\r", True),
     ("y = \"\v\f\"\ns = f\"{x=}\"\n", True),
 
+    # Implicit concat merging a leading plain string part must not misdirect the self-doc `{`-anchor
+    # onto that part.
+    ('"{" f"{x=}"', True),
+    ('"{x}" f"{y=}"', True),
+    ('("{\\n" f"{x=}")', True),
+    ('"}" f"{x=}"', True),
+
     ("a = 1\nf'a={a}'", False),
     ("a = 1\nf'={a}'", False),
     ("f'{a != b}'", False),

--- a/tests/fstring_detector.py
+++ b/tests/fstring_detector.py
@@ -289,6 +289,10 @@ class FStringDetectorTests(VerminTest):
     ('f"""{x  # c\n:>3}"""', True),
     ('f"""{x\n# comment\n}"""', True),
     ("f\"{'#notacomment'}\"", False),
+
+    # A `#` before the format spec is a comment, but after the `:` it is literal text.
+    ('q = "zz" + f"""{a  # c\n}"""', True),
+    ('q = "zz" + f"""{x:>3  # c\n}"""', False),
   ])
   def test_pep701_comment_region(self, source, expected):
     detector = FStringDetector(source)

--- a/tests/fstring_detector.py
+++ b/tests/fstring_detector.py
@@ -390,8 +390,13 @@ class FStringDetectorParityTests(VerminTest):
   def test_codepoint_helpers(self):
     """Codepoint helpers on a truncated UTF-8 column and out-of-range spans."""
     self.assertEqual(1, self.detector._codepoint_col(["é"], 1, 1))
-    self.assertIsNone(self.detector._span_offset(self.detector._lines, 4, 0, 3))
+    self.assertIsNone(self.detector._span_offset(self.detector._lines, 4, 0))
     self.assertEqual(0, self.detector._codepoint_length(["a"], 9, 0, 9, 0))
+
+    # A `lineno` in range for the char count but beyond the actual line count must return `None`
+    # rather than index past the per-line offset array.
+    single_line = FStringDetector("abc")
+    self.assertIsNone(single_line._span_offset(single_line._lines, 2, 0))
 
   def test_scanner_guards(self):
     """String/brace scanners that run past their end without a closing token."""

--- a/tests/fstring_detector.py
+++ b/tests/fstring_detector.py
@@ -1,0 +1,262 @@
+import ast
+
+from vermin.fstring_detector import FStringDetector
+
+from .testutils import VerminTest
+
+
+def joined_strs(source):
+  tree = ast.parse(source)
+  return [n for n in ast.walk(tree) if isinstance(n, ast.JoinedStr)]
+
+
+class FStringDetectorTests(VerminTest):
+  def assert_self_doc(self, source, expected):
+    detector = FStringDetector(source)
+    nodes = joined_strs(source)
+    self.assertTrue(nodes, "no f-string in: " + source)
+    self.assertEqual(expected, any(detector.is_self_doc(n) for n in nodes), source)
+
+  def assert_pep701(self, source, expected):
+    """Assert the source's f-strings trigger the named PEP 701 violation. `None` expectation means
+    "no violation", not "no f-string", which is asserted separately.
+    """
+    detector = FStringDetector(source)
+    nodes = joined_strs(source)
+    self.assertTrue(nodes, "no f-string in: " + source)
+    if expected is None:
+      self.assertTrue(all(detector.pep701_violation(n) is None for n in nodes), source)
+    else:
+      self.assertTrue(any(detector.pep701_violation(n) == expected for n in nodes), source)
+
+  def test_none_source(self):
+    detector = FStringDetector(None)
+    node = joined_strs('f"{x}"')[0]
+    self.assertFalse(detector.is_self_doc(node))
+    self.assertIsNone(detector.pep701_violation(node))
+    # pylint: disable=W0212
+    self.assertIsNone(detector._read_fstring_token(node, None))
+
+  def test_input_guards(self):
+    detector = FStringDetector('f"{x}"')
+    bare = ast.JoinedStr()
+    const = ast.Constant(value="a")
+    self.assertIsNone(detector.pep701_violation(bare))
+    self.assertFalse(detector.is_self_doc(const))
+    self.assertIsNone(detector.pep701_violation(const))
+    # pylint: disable=W0212
+    self.assertIsNone(detector._read_fstring_token(bare, 'f"{x}"'.splitlines()))
+    self.assertIsNone(detector._read_fstring_token(bare, []))
+
+  @VerminTest.skipUnlessVersion(3, 8)
+  @VerminTest.parameterized_args([
+    ("f'{a=}'", True),
+    ("f'hello {name=}'", True),
+    ("f'{b=}={a}'", True),
+    ("f'{a =}'", True),
+    ("f'{ a=}'", True),
+    ("f'{a= }'", True),
+    ("f'{ a = }'", True),
+    ("f'{1+1=}'", True),
+    ("f'{a+b=}'", True),
+    ("f'{-5=}'", True),
+    ("f'{(1,2,3)=}'", True),
+    ("f'{ {1,2,3}=}'", True),
+    ("f'{[x for x in [1,2,3]]=}'", True),
+    ("f'{0==1=}'", True),
+    ("f'{3.14=:10.10}'", True),
+    ("f'{3.14=!s:10.10}'", True),
+    ("f'{x=!r}'", True),
+    ("f'{x=:.2f}'", True),
+    ("f'{f\"{3.1415=:.1f}\":*^20}'", True),
+    ("f'{{literal}}{a=}'", True),
+    ("f'''{\n3\n=}'''", True),
+    ("f'{f(a=4)=}'", True),
+    ("f\"\\N{EXCLAMATION MARK}{a=}\"", True),
+
+    # CRLFs must not shift the byte offsets of nodes on later lines.
+    ("x = 1\r\ns = f\"{x=}\"\r\n", True),
+    ("x = 1\r\ns = f\"{x=!r}\"\r\n", True),
+
+    # Bare `\r` endings and parser-only separators, like `\v` and `\f`, in string literals must not
+    # shift offsets either.
+    ("x = 1\rs = f\"{x=}\"\r", True),
+    ("y = \"\v\f\"\ns = f\"{x=}\"\n", True),
+
+    ("a = 1\nf'a={a}'", False),
+    ("a = 1\nf'={a}'", False),
+    ("f'{a != b}'", False),
+    ("f'{a == b}'", False),
+    ("f'{a >= b}'", False),
+    ("f'{a <= b}'", False),
+    ("f'{x:=10}'", False),
+    ("f'hello {name!r}'", False),
+    ("f'{x!r}'", False),
+    ("f'{x!s}'", False),
+    ("f'{x!a}'", False),
+    ("f'{x:.2f}'", False),
+    ("f'val={val:.2f}'", False),
+    ("f'{(a+b)}={x!r}'", False),
+    ("f'{{x={a}}}'", False),
+    ("f'{x}'", False),
+    ("f'{x:{width}}'", False),
+    ("f'={cos(radians(theta)):.3f}'", False),
+    ("x = 1\r\ns = f\"{x+1}\"\r\n", False),
+    ("x = 1\rs = f\"{x+1}\"\r", False),
+  ])
+  def test_self_doc(self, source, expected):
+    self.assert_self_doc(source, expected)
+
+  @VerminTest.skipUnlessVersion(3, 12)
+  @VerminTest.parameterized_args([
+    ('f"{\n1+2\n}"', "multi_line"),
+    ('f"{\n  x +\n  y\n}"', "multi_line"),
+    ("f\"{\n'''a'''\n}\"", "multi_line"),
+    ("'''lit''' f\"{x\n+y}\"", "multi_line"),
+    ('f"{a \\\n}"', "multi_line"),
+
+    ('f"{x}"', None),
+    ('f"{x:10}"', None),
+    ("f'''{\n3\n}'''", None),
+    ('f"\\N{EXCLAMATION MARK}{x}"', None),
+    ('s = (f"got {x}: "\n     f"done")', None),
+    ('s = f"{a}" f"{b}"', None),
+    ('s = f"lit {a}" f"""{b\n+ c}"""', None),
+    ('s = (f"got {x}: "\n     f"""done\n{p\n+ q}""")', None),
+  ])
+  def test_pep701_multi_line(self, source, expected):
+    self.assert_pep701(source, expected)
+
+  @VerminTest.skipUnlessVersion(3, 12)
+  @VerminTest.parameterized_args([
+    ('f"outer {f"inner"}"', "nested_same_quote"),
+    ("f'outer {f'inner'}'", "nested_same_quote"),
+    ('f"""outer {f"""inner"""}"""', "nested_same_quote"),
+    ('f"outer {f"""inner"""}"', "nested_same_quote"),
+    ('f"{x:{f".2f"}}"', "nested_same_quote"),
+    ('f"1 {f"2 {f"3"}"}"', "nested_same_quote"),
+
+    ('f"""outer {f"inner"}"""', None),
+    ('f"outer {f\'inner\'}"', None),
+    ("f'outer {f\"inner\"}'", None),
+  ])
+  def test_pep701_nested_same_quote(self, source, expected):
+    self.assert_pep701(source, expected)
+
+  @VerminTest.skipUnlessVersion(3, 12)
+  @VerminTest.parameterized_args([
+    ("'lit' f\"{f\"{x}\"}\"", "nested_same_quote"),
+    ('"""lit""" f"{f"{x}"}"', "nested_same_quote"),
+    ("'''lit''' f\"{f\"{x}\"}\"", "nested_same_quote"),
+    ("f'{\"lit\" f'{x}'}'", "nested_same_quote"),
+    ('f"""{rf"""{x}"""}"""', "nested_same_quote"),
+    ('f"{fr"""{x}"""}"', "nested_same_quote"),
+    ("f'outer {rf'''{x}'''}'", "nested_same_quote"),
+    ('f"{F"e{fr"""{x}"""}config"}"', "nested_same_quote"),
+    ("('lit'\n# comment between\n f\"{f\"{x}\"}\")", "nested_same_quote"),
+
+    ("'pre' f\"{f'{x}'}\"", None),
+    ("'''pre''' f\"{f'{x}'}\"", None),
+
+    # Format-spec nested f-strings are valid pre-3.12 even when same-quoted.
+    ("f\"{x:{f'{y}'}}\"", None),
+    ('f"""{x:{f"{y}"}}"""', None),
+  ])
+  def test_pep701_nested_same_quote_implicit_concat(self, source, expected):
+    self.assert_pep701(source, expected)
+
+  @VerminTest.skipUnlessVersion(3, 12)
+  @VerminTest.parameterized_args([
+    ("f\"{'\\n'.join(x)}\"", "backslash"),
+    ("f\"{r'\\n'}\"", "backslash"),
+
+    ("f\"{chr(10)}\"", None),
+    ("f'hello\\nworld'", None),
+  ])
+  def test_pep701_backslash(self, source, expected):
+    self.assert_pep701(source, expected)
+
+  @VerminTest.skipUnlessVersion(3, 12)
+  def test_pep701_backslash_line_continuation(self):
+    source = 'f"{a \\\n}"'
+    node = joined_strs(source)[0].values[0]
+    detector = FStringDetector(source)
+    # pylint: disable=W0212
+    self.assertTrue(detector._has_pep701_backslash(node, source.splitlines()))
+
+  @VerminTest.skipUnlessVersion(3, 12)
+  @VerminTest.parameterized_args([
+    ('f"""{x  # comment\n}"""', "comment"),
+    ('f"""{x\n# comment\n}"""', "comment"),
+
+    ("f\"{'#notacomment'}\"", None),
+    ('f"{x}"', None),
+
+    # `#` in a format spec is spec filler text, valid since 3.6.
+    ('f"""{x:>3  # c\n}"""', None),
+    ('f"""{x:{w}  # c\n}"""', None),
+    ('f"""{x!r:>3  # c\n}"""', None),
+
+    # A comment before the format spec is a PEP 701 comment.
+    ('f"""{x  # c\n:>3}"""', "comment"),
+  ])
+  def test_pep701_comment(self, source, expected):
+    self.assert_pep701(source, expected)
+
+  @VerminTest.skipUnlessVersion(3, 12)
+  @VerminTest.parameterized_args([
+    ("('lit' f\"{x}\")", ('"', False)),
+    ("('''lit''' f'{x}')", ("'", False)),
+    ('(f"lit {a}" f"""{b\n+ c}""")', ('"', False)),
+    ('f"{f"{x}"}"', ('"', False)),
+    ('f"""{rf"""{x}"""}"""', ('"', True)),
+    ('rf"raw {x}"', ('"', False)),
+    ("(f'lit' f\"{x}\")", ("'", False)),
+  ])
+  def test_read_fstring_token(self, source, expected):
+    detector = FStringDetector(source)
+    nodes = joined_strs(source)
+    self.assertTrue(nodes, "no f-string in: " + source)
+    # pylint: disable=W0212
+    got = detector._read_fstring_token(nodes[0], source.splitlines())
+    self.assertEqual(expected, got, source)
+
+  @VerminTest.skipUnlessVersion(3, 12)
+  @VerminTest.parameterized_args([
+    ('f"""{x:>3  # c\n}"""', False),
+    ('f"""{x:{w}  # c\n}"""', False),
+    ('f"""{x!r:>3  # c\n}"""', False),
+    ('f"""{x  # c\n:>3}"""', True),
+    ('f"""{x\n# comment\n}"""', True),
+    ("f\"{'#notacomment'}\"", False),
+  ])
+  def test_pep701_comment_region(self, source, expected):
+    detector = FStringDetector(source)
+    node = joined_strs(source)[0].values[0]
+    # pylint: disable=W0212
+    got = detector._has_pep701_comment(node, source.splitlines())
+    self.assertEqual(expected, got, source)
+
+  @VerminTest.skipUnlessVersion(3, 12)
+  @VerminTest.parameterized_args([
+    ("x = 1\r\ns = f\"{f\"{x}\"}\"\r\n", "nested_same_quote"),
+    ("x = 1\r\ns = f\"{\r\nx\r\n}\"\r\n", "multi_line"),
+    ("x = 1\r\ns = f\"{x  # c\r\n}\"\r\n", "multi_line"),
+    ("x = 1\r\ns = f\"\"\"{x  # c\r\n}\"\"\"\r\n", "comment"),
+    ("x = 1\r\n'''lit''' f\"{x\n+y}\"\r\n", "multi_line"),
+    ("x = 1\r\ns = f\"{x!r}\"\r\n", None),
+  ])
+  def test_pep701_crlf(self, source, expected):
+    self.assert_pep701(source, expected)
+
+  @VerminTest.skipUnlessVersion(3, 12)
+  @VerminTest.parameterized_args([
+    # Bare `\r` endings and parser-only separators, like `\v` and `\f`, in string literals must not
+    # shift offsets of nodes on later lines.
+    ("x = 1\rs = f\"{f\"{x}\"}\"\r", "nested_same_quote"),
+    ("y = \"\v\f\"\ns = f\"{f\"{x}\"}\"\n", "nested_same_quote"),
+    ("x = 1\rs = f\"{x}\"\r", None),
+    ("y = \"\v\f\"\ns = f\"{x}\"\n", None),
+  ])
+  def test_pep701_parser_line_breaks(self, source, expected):
+    self.assert_pep701(source, expected)

--- a/tests/fstring_detector.py
+++ b/tests/fstring_detector.py
@@ -78,6 +78,8 @@ class FStringDetectorTests(VerminTest):
     ("f\"{     2      +     2    =    }\"", True),
     ("f\"{''=}\"", True),
     ('f"""{1=: "this" is fine}"""', True),
+    ("f'{(x)=}'", True),
+    ("f'{a[0]=}'", True),
 
     # CRLFs must not shift the byte offsets of nodes on later lines.
     ("x = 1\r\ns = f\"{x=}\"\r\n", True),
@@ -238,6 +240,7 @@ class FStringDetectorTests(VerminTest):
   @VerminTest.parameterized_args([
     ('f"""{x  # comment\n}"""', "comment"),
     ('f"""{x\n# comment\n}"""', "comment"),
+    ("f\"\"\"{a + 'x'  # c\n}\"\"\"", "comment"),
 
     ("f\"{'#notacomment'}\"", None),
     ('f"{x}"', None),
@@ -310,3 +313,173 @@ class FStringDetectorTests(VerminTest):
   ])
   def test_pep701_parser_line_breaks(self, source, expected):
     self.assert_pep701(source, expected)
+
+
+def _set_span(node, span):
+  node.lineno, node.col_offset, node.end_lineno, node.end_col_offset = span
+  return node
+
+
+def _name(identifier, span):
+  return _set_span(ast.Name(id=identifier, ctx=ast.Load()), span)
+
+
+def _joined(values, span):
+  return _set_span(ast.JoinedStr(values=values), span)
+
+
+def _formatted(value, span):
+  return _set_span(ast.FormattedValue(value=value, conversion=-1, format_spec=None), span)
+
+
+class FStringDetectorParityTests(VerminTest):
+  """PEP 701 parity tests that run on every interpreter, covering analysis the 3.12-gated suite
+  never reaches.
+  """
+
+  # pylint: disable=protected-access
+
+  def setUp(self):
+    super().setUp()
+    self.none_detector = FStringDetector(None)
+
+    # The source code is inert on purpose, being short and single-line with no braces, quotes, or
+    # backslashes. And thus the fabricated spans have nothing to find and must always miss.
+    self.detector = FStringDetector("xyz")
+
+  def assert_pep701_none(self, source, span, token):
+    detector = FStringDetector(source)
+    nodes = joined_strs(source)
+    self.assertTrue(nodes, "no f-string in: " + source)
+
+    # Re-apply the 3.12+ top-level span, since pre-3.12 parsers pin it to the whole f-string.
+    for val in nodes[0].values:
+      if isinstance(val, ast.FormattedValue):
+        _set_span(val, span)
+        break
+
+    for node in nodes:
+      self.assertIsNone(detector.pep701_violation(node), source)
+
+    got = detector._read_fstring_token(nodes[0], source.splitlines())
+    self.assertEqual(token, got, source)
+
+  # Spans as 3.12+ reports them, re-applied where pre-3.12 parsers pin fields to the f-string.
+  @VerminTest.parameterized_args([
+    ('f"{{lit}}{x}"', (1, 9, 1, 12), ('"', False)),
+    ('f"{a[\'x\']}"', (1, 2, 1, 10), ('"', False)),
+    ('f"{x:{f\'{y}\'}}"', (1, 2, 1, 14), ('"', False)),
+    ("f'outer {f\"mid\"}'", (1, 8, 1, 16), ("'", False)),
+    ('f"\\N{EXCLAMATION MARK}{x}"', (1, 22, 1, 25), ('"', False)),
+    ('r"lit" f"{x}"', (1, 9, 1, 12), ('"', False)),
+    ('("lit"\n# c\n f"{y}")', (3, 3, 3, 6), ('"', False)),
+    ("('''lit''' f'{x}')", (1, 13, 1, 16), ("'", False)),
+    ("f\"\"\"{a + '#'}\"\"\"", (1, 4, 1, 13), ('"', True)),
+    ('f"\\\\{x}"', (1, 4, 1, 7), ('"', False)),
+  ])
+  def test_pep701_cross_version(self, source, spans, token):
+    self.assert_pep701_none(source, spans, token)
+
+  def test_codepoint_helpers(self):
+    """Codepoint helpers on a truncated UTF-8 column and out-of-range spans."""
+    self.assertEqual(1, self.detector._codepoint_col(["é"], 1, 1))
+    self.assertIsNone(self.detector._span_offset(self.detector._lines, 4, 0, 3))
+    self.assertEqual(0, self.detector._codepoint_length(["a"], 9, 0, 9, 0))
+
+  def test_scanner_guards(self):
+    """String/brace scanners that run past their end without a closing token."""
+    self.assertEqual(3, self.detector._skip_string("f\"ab", 1, 3, 4))
+    self.assertEqual(4, self.detector._fstring_body_end("f\"ab", 1, 4, '"', False, None, None))
+    self.assertEqual(4, self.detector._field_end("f\"{x", 3, 4))
+
+  def test_token_span_guards(self):
+    # A joined span past the source.
+    self.assertIsNone(
+      self.detector._read_fstring_token(_joined([], (9, 0, 9, 1)), self.detector._lines))
+
+    # An end span past the source.
+    self.assertIsNone(
+      self.detector._read_fstring_token(_joined([], (1, 0, 9, 1)), self.detector._lines))
+
+    # A field span past the source.
+    bad_fv = _formatted(_name("x", (1, 1, 1, 2)), (9, 1, 9, 2))
+    self.assertIsNone(
+      self.detector._read_fstring_token(_joined([bad_fv], (1, 0, 1, 5)), self.detector._lines))
+
+  def test_build_field_contexts_guards(self):
+    # A node without `end_col_offset`, like it was pre-3.8, yields no contexts.
+    class BareStringNode:
+      def __init__(self, values):
+        self.values = values
+        self.lineno = 1
+        self.col_offset = 0
+        self.end_lineno = 1
+    truncated = BareStringNode([])
+    self.assertEqual({}, self.detector._build_field_contexts(truncated, self.detector._lines)[0])
+
+    # A joined span past the source yields no contexts.
+    self.assertEqual({}, self.detector._build_field_contexts(
+      _joined([], (1, 0, 9, 1)), self.detector._lines)[0])
+
+    # Real literals re-scanned under an empty joined node resolve nothing.
+    for source, span in (("f\"a{b}c\"", (1, 2, 1, 7)),
+                         ("f\"{{x}}\"", (1, 2, 1, 6)),
+                         ("f\"ab\\N{SPACE}cd\"", (1, 2, 1, 13))):
+      fabricated = FStringDetector(source)
+      contexts = fabricated._build_field_contexts(_joined([], span), [source])[0]
+      self.assertEqual({}, contexts)
+
+    # A brace outside any f-string literal falls back to the default context.
+    mid = FStringDetector("f\"a\" {x} f\"b\"")
+    contexts, default = mid._build_field_contexts(_joined([], (1, 0, 1, 13)), ["f\"a\" {x} f\"b\""])
+    self.assertEqual({5: ('"', False)}, contexts)
+    self.assertEqual(('"', False), default)
+
+  def test_resolve_field_context_fallback(self):
+    no_pos = ast.FormattedValue(value=_name("x", (1, 1, 1, 2)), conversion=-1, format_spec=None)
+    default = ("'", True)
+    self.assertEqual(default, self.detector._resolve_field_context(no_pos, {}, default))
+
+  def test_self_doc_walk_guards(self):
+    candidate = \
+      ast.FormattedValue(value=_name("a", (1, 1, 1, 2)), conversion=ord("r"), format_spec=None)
+
+    # An empty f-string has no fields to walk.
+    self.assertFalse(self.none_detector.is_self_doc(_joined([], (1, 0, 1, 3))))
+
+    # A joined span past the source triggers the out-of-range guard.
+    self.assertFalse(self.detector.is_self_doc(_joined([candidate], (9, 0, 9, 3))))
+
+    # A normal `!r` field is simply not self-documenting.
+    self.assertFalse(FStringDetector("f\"x\"").is_self_doc(_joined([candidate], (1, 0, 1, 4))))
+
+    # Value node lacking end offsets, so the walk can't read past its span.
+    value_no_end = ast.Name(id="a")
+    value_no_end.lineno, value_no_end.col_offset = 1, 3
+    fv_no_end = ast.FormattedValue(value=value_no_end, conversion=ord("r"), format_spec=None)
+    fv_no_end.lineno, fv_no_end.col_offset = 1, 2
+    fv_no_end.end_lineno, fv_no_end.end_col_offset = 1, 4
+    self.assertFalse(FStringDetector("f\"{x}\"").is_self_doc(_joined([fv_no_end], (1, 0, 1, 5))))
+
+    # Value truncated at the span's edge, where no `=` can follow.
+    truncated_fv = _formatted(_name("x", (1, 3, 1, 4)), (1, 2, 1, 4))
+    self.assertFalse(FStringDetector("f\"{x}\"").is_self_doc(_joined([truncated_fv], (1, 0, 1, 4))))
+
+  def test_violation_scan_guards(self):
+    sample = _formatted(_name("x", (1, 2, 1, 5)), (1, 2, 1, 6))
+    self.assertFalse(self.none_detector._has_same_quote_string(sample, '"'))
+    self.assertFalse(self.none_detector._has_pep701_backslash(sample, None))
+    self.assertFalse(self.none_detector._has_pep701_comment(sample, None))
+
+    bad_span = _formatted(_name("x", (1, 1, 1, 2)), (9, 0, 9, 1))
+    self.assertFalse(self.detector._has_same_quote_string(bad_span, '"'))
+    self.assertFalse(self.detector._has_pep701_comment(bad_span, self.detector._lines))
+
+  def test_backslash_scan(self):
+    cont = FStringDetector("f\"{a \\\n}\"")
+    cont_fv = _formatted(_name("a", (1, 3, 1, 4)), (1, 2, 2, 1))
+    self.assertTrue(cont._has_pep701_backslash(cont_fv, cont._lines))
+
+    token_error = FStringDetector("f\"ab'\\\nc}\"")
+    token_fv = _formatted(_name("x", (1, 3, 1, 6)), (1, 2, 1, 6))
+    self.assertFalse(token_error._has_pep701_backslash(token_fv, token_error._lines))

--- a/tests/fstring_detector.py
+++ b/tests/fstring_detector.py
@@ -119,6 +119,7 @@ class FStringDetectorTests(VerminTest):
     ("f\"{\n'''a'''\n}\"", "multi_line"),
     ("'''lit''' f\"{x\n+y}\"", "multi_line"),
     ('f"{a \\\n}"', "multi_line"),
+    ("f'abc {\nx\n}'", "multi_line"),
 
     ('f"{x}"', None),
     ('f"{x:10}"', None),
@@ -140,6 +141,15 @@ class FStringDetectorTests(VerminTest):
     ('f"outer {f"""inner"""}"', "nested_same_quote"),
     ('f"{x:{f".2f"}}"', "nested_same_quote"),
     ('f"1 {f"2 {f"3"}"}"', "nested_same_quote"),
+    ('f"normal {f"{a=}"} normal"', "nested_same_quote"),
+    ('f"normal {f"{a:.3f}"} normal"', "nested_same_quote"),
+    ('f"normal { {f"{ { [1, 2] } }" } } normal"', "nested_same_quote"),
+    ('f"foo {f"bar {x}"} baz"', "nested_same_quote"),
+    ('value = f"{f"\\{1}"}"', "nested_same_quote"),
+    ('value = rf"{f"\\{1}"}"', "nested_same_quote"),
+    ('value = f"{rf"\\{1}"}"', "nested_same_quote"),
+    ('_ = "a" f"b {f"c" f"d"} e" "f"', "nested_same_quote"),
+    ('f"\\"foo\\" {f"\\"foo\\""} \\"\\""', "nested_same_quote"),
 
     ('f"""outer {f"inner"}"""', None),
     ('f"outer {f\'inner\'}"', None),
@@ -174,6 +184,10 @@ class FStringDetectorTests(VerminTest):
   @VerminTest.parameterized_args([
     ("f\"{'\\n'.join(x)}\"", "backslash"),
     ("f\"{r'\\n'}\"", "backslash"),
+    ("f\"{'\\''}\"", "backslash"),
+    ("t = f\"{'\\InHere'=}\"", "backslash"),
+    ('f"{"\\xFF\\N{space}"=}"', "backslash"),
+    ('f"{r"\\xFF"=}"', "backslash"),
 
     ("f\"{chr(10)}\"", None),
     ("f'hello\\nworld'", None),

--- a/tests/general.py
+++ b/tests/general.py
@@ -238,7 +238,7 @@ c = 3
 
   def test_detect_paths(self):
     paths = detect_paths([abspath("vermin")], config=self.config)
-    self.assertEqual(20, len(paths))
+    self.assertEqual(21, len(paths))
 
   def test_detect_hidden_paths(self):
     tmp_fld = mkdtemp()

--- a/tests/lang.py
+++ b/tests/lang.py
@@ -180,6 +180,222 @@ class VerminLanguageTests(VerminTest):
     self.config.enable_feature("fstring-self-doc")
     self.assert_self_doc(source)
 
+  def assert_pep701(self, source):
+    visitor = self.visit(source)
+    self.assertTrue(visitor.fstrings())
+    self.assertTrue(visitor.fstrings_pep701())
+    self.assertOnlyIn((3, 12), visitor.minimum_versions())
+
+  def assert_not_pep701(self, source):
+    visitor = self.visit(source)
+    self.assertTrue(visitor.fstrings())
+    self.assertFalse(visitor.fstrings_pep701())
+    self.assertOnlyIn((3, 6), visitor.minimum_versions())
+
+  @VerminTest.skipUnlessVersion(3, 12)
+  @VerminTest.parameterized_args([
+    ("f\"{chr(10)}\"",),
+    ("f\"{'#notacomment'}\"",),
+    ("f'hello {name}'",),
+    ("f'''{x}'''",),
+    ("f'''{\n3\n}'''",),
+
+    # Mixed triple/single (valid pre-3.12).
+    ('f"""outer {f"inner"}"""',),
+
+    # Different-quote nesting (valid pre-3.12).
+    ('f"outer {f\'inner\'}"',),
+    ("f'outer {f\"inner\"}'",),
+
+    # Backslash in literal, not expression.
+    ("f'hello\\nworld'",),
+  ])
+  def test_pep701_not_detected(self, source):
+    self.config.enable_feature("fstring-pep701")
+    self.assert_not_pep701(source)
+
+  @VerminTest.skipUnlessVersion(3, 12)
+  @VerminTest.parameterized_args([
+    # Same-quote nesting.
+    ('f"outer {f"inner"}"',),
+    ("f'outer {f'inner'}'",),
+    ('f"""outer {f"""inner"""}"""',),
+    ("f'''outer {f'''inner'''}'''",),
+    ('f"1 {f"2 {f"3"}"}"',),
+
+    # Format-spec nesting.
+    ('f"{x:{f".2f"}}"',),
+
+    # Single outer with triple inner.
+    ('f"outer {f"""inner"""}"',),
+
+    # Multi-line expressions.
+    ('f"{\n1+2\n}"',),
+    ("f\"{\n'''a'''\n}\"",),
+
+    # Backslash.
+    ("f\"{'\\n'.join(x)}\"",),
+    ("f\"{r'\\n'}\"",),
+    ('f"{a \\\n}"',),
+
+    # Comment.
+    ('f"{x  # comment\n}"',),
+    ('f"{\n# comment\n1+2\n}"',),
+  ])
+  def test_pep701_detected(self, source):
+    self.config.enable_feature("fstring-pep701")
+    self.assert_pep701(source)
+
+  @VerminTest.skipUnlessVersion(3, 12)
+  @VerminTest.parameterized_args([
+    ("'lit' f\"{f\"{x}\"}\"",),
+    ('"""lit""" f"{f"{x}"}"',),
+    ("'''lit''' f\"{f\"{x}\"}\"",),
+    ("f'{\"lit\" f'{x}'}'",),
+    ('f"""{rf"""{x}"""}"""',),
+    ('f"{fr"""{x}"""}"',),
+    ("f'outer {rf'''{x}'''}'",),
+    ('f"{F"é{fr"""{x}"""}config"}"',),
+    ("('lit'\n# comment between\n f\"{f\"{x}\"}\")",),
+    ("'''lit''' f\"{x\n+y}\"",),
+    ('f"""{x  # c\n:>3}"""',),
+  ])
+  def test_pep701_implicit_concat(self, source):
+    self.config.enable_feature("fstring-pep701")
+    self.assert_pep701(source)
+
+  @VerminTest.skipUnlessVersion(3, 12)
+  @VerminTest.parameterized_args([
+    ('f"{x\n# comment\n}"',),
+    ('f"""{x\n# comment\n}"""',),
+    ('f"""{x  # comment\n}"""',),
+    ('f"""{x  # c\n:>3}"""',),
+  ])
+  def test_pep701_comment_variants(self, source):
+    self.config.enable_feature("fstring-pep701")
+    self.assert_pep701(source)
+
+  @VerminTest.skipUnlessVersion(3, 12)
+  def test_pep701_feature_flag(self):
+    self.config.reset()
+    visitor = self.visit('f"outer {f"inner"}"')
+    self.assertTrue(visitor.fstrings())
+    self.assertFalse(visitor.fstrings_pep701())
+    self.assertOnlyIn((3, 6), visitor.minimum_versions())
+
+    self.config.enable_feature("fstring-pep701")
+    visitor = self.visit('f"outer {f"inner"}"')
+    self.assertTrue(visitor.fstrings())
+    self.assertTrue(visitor.fstrings_pep701())
+    self.assertOnlyIn((3, 12), visitor.minimum_versions())
+
+  # Ordinary 3.6+ valid fstrings must never be flagged as PEP 701. Especially important on pre-3.12
+  # interpreters.
+  @VerminTest.skipUnlessVersion(3, 6)
+  @VerminTest.parameterized_args([
+    ('f"{x}"',),
+    ('f"{x:10}"',),
+    ('f"{x:#04x}"',),
+    ('f"{x!r}"',),
+    ("f'{x}'",),
+    ("f'{x:10}'",),
+    ("f'{x!s}'",),
+    ('f"{x:>#12}"',),
+    ('f"{x:#x}"',),
+    ('f"{x:{width}}"',),
+    ('f"value: {x:#08x}"',),
+    ('f"hello {name}"',),
+
+    # Non-ASCII literal text before a field shifts AST byte-based column offsets away from
+    # code-point positions. Post-3.12 parsers removed the pinned field positions, exposing the
+    # format spec `#x` and similar as a false comment or backslash PEP 701 trigger.
+    ('f"é{x}"',),
+    ('f"é{x:#x}"',),
+    ('f"é{x:#04x}"',),
+    ('f"┐{x}"',),
+    ('f"┐{p - 8:#x} ◂"',),
+    ("f'é{x:#x}'",),
+    ('rf"00:0000│\\s+{sp - 8:#x} ◂— 0"',),
+    ('f"euro€ {x:#x} ~"',),
+    ("f''",),
+    ("f'{x}'",),
+
+    # Pre-3.12 parsers pin every `FormattedValue` to the whole fused span, with `lineno=1` and
+    # `end_lineno=N`, which previously read as a multi-line implicit string concat expression.
+    ('s = (f"got {x}: "\n     f"done")',),
+    ('s = (f"done"\n     f"got {x}: ")',),
+    ('s = (f"{a}"\n     f"{b}")',),
+    ('s = (f"{a}"\n     "literal")\n',),
+    ('s = (f"done"\n     f"done")',),
+    ('s = f"{a}" f"{b}"',),
+
+    # `#` inside a format spec is spec filler text, not a comment. Valid since 3.6.
+    ('f"""{x:>3  # c\n}"""',),
+    ('f"""{x:{w}  # c\n}"""',),
+    ('f"""{x!r:>3  # c\n}"""',),
+
+    # Leading plain literal hides a differently-quoted nested fstring.
+    ('\'pre\' f"{f\'{x}\'}"',),
+    ("'''pre''' f\"{f'{x}'}\"",),
+
+    # Format-spec nested fstrings are valid pre-3.12 even when same-quoted.
+    ('f"{x:{f\'{y}\'}}"',),
+    ('f"""{x:{f"{y}"}}"""',),
+
+    # Multi-line expression in the triple-quoted trailing part of an implicit concatenation.
+    ('s = f"lit {a}" f"""{b\n+ c}"""',),
+  ])
+  def test_fstrings_pep701_no_false_positives(self, source):
+    self.config.enable_feature("fstring-pep701")
+    visitor = self.visit(source)
+    self.assertFalse(visitor.fstrings_pep701())
+    self.assertOnlyIn((3, 6), visitor.minimum_versions())
+
+  @VerminTest.skipUnlessVersion(3, 12)
+  def test_fstrings_self_doc_and_pep701(self):
+    self.config.enable_feature("fstring-self-doc")
+    self.config.enable_feature("fstring-pep701")
+
+    visitor = self.visit("a = 1\nf'{a=}'")
+    self.assertTrue(visitor.fstrings())
+    self.assertTrue(visitor.fstrings_self_doc())
+    self.assertFalse(visitor.fstrings_pep701())
+    self.assertOnlyIn((3, 8), visitor.minimum_versions())
+
+    visitor = self.visit('f"outer {f"inner"}"')
+    self.assertTrue(visitor.fstrings())
+    self.assertFalse(visitor.fstrings_self_doc())
+    self.assertTrue(visitor.fstrings_pep701())
+    self.assertOnlyIn((3, 12), visitor.minimum_versions())
+
+    # Self-doc inside PEP 701 nested fstring.
+    visitor = self.visit('f"result: {f"{x=}"}"')
+    self.assertTrue(visitor.fstrings())
+    self.assertTrue(visitor.fstrings_self_doc())
+    self.assertTrue(visitor.fstrings_pep701())
+    self.assertOnlyIn((3, 12), visitor.minimum_versions())
+
+    # Same-quote nesting whose inner field is self-doc, and a backslash-in-expression combined with
+    # a self-doc marker.
+    visitor = self.visit('f"normal {f"{a=}"} normal"')
+    self.assertTrue(visitor.fstrings())
+    self.assertTrue(visitor.fstrings_self_doc())
+    self.assertTrue(visitor.fstrings_pep701())
+    self.assertOnlyIn((3, 12), visitor.minimum_versions())
+
+    visitor = self.visit("t = f\"{'\\InHere'=}\"")
+    self.assertTrue(visitor.fstrings())
+    self.assertTrue(visitor.fstrings_self_doc())
+    self.assertTrue(visitor.fstrings_pep701())
+    self.assertOnlyIn((3, 12), visitor.minimum_versions())
+
+    # The double-quoted empty-string self-doc form only parses on 3.12+.
+    visitor = self.visit('f"{""=}"')
+    self.assertTrue(visitor.fstrings())
+    self.assertTrue(visitor.fstrings_self_doc())
+    self.assertFalse(visitor.fstrings_pep701())
+    self.assertOnlyIn((3, 8), visitor.minimum_versions())
+
   @VerminTest.skipUnlessVersion(3, 5)
   def test_coroutines_async(self):
     visitor = self.visit("async def func():\n\tpass")

--- a/tests/lang.py
+++ b/tests/lang.py
@@ -185,6 +185,26 @@ class VerminLanguageTests(VerminTest):
     self.config.enable_feature("fstring-self-doc")
     self.assert_self_doc(source)
 
+  @VerminTest.skipUnlessVersion(3, 8)
+  def test_self_doc_feature_flag(self):
+    # Enabled by default.
+    visitor = self.visit("a = 1\nf'{a=}'")
+    self.assertTrue(visitor.fstrings())
+    self.assertTrue(visitor.fstrings_self_doc())
+    self.assertOnlyIn((3, 8), visitor.minimum_versions())
+
+    self.config.clear_features()
+    visitor = self.visit("a = 1\nf'{a=}'")
+    self.assertTrue(visitor.fstrings())
+    self.assertFalse(visitor.fstrings_self_doc())
+    self.assertOnlyIn((3, 6), visitor.minimum_versions())
+
+    self.config.enable_feature("fstring-self-doc")
+    visitor = self.visit("a = 1\nf'{a=}'")
+    self.assertTrue(visitor.fstrings())
+    self.assertTrue(visitor.fstrings_self_doc())
+    self.assertOnlyIn((3, 8), visitor.minimum_versions())
+
   def assert_pep701(self, source):
     visitor = self.visit(source)
     self.assertTrue(visitor.fstrings())
@@ -282,7 +302,14 @@ class VerminLanguageTests(VerminTest):
 
   @VerminTest.skipUnlessVersion(3, 12)
   def test_pep701_feature_flag(self):
+    # Enabled by default.
     self.config.reset()
+    visitor = self.visit('f"outer {f"inner"}"')
+    self.assertTrue(visitor.fstrings())
+    self.assertTrue(visitor.fstrings_pep701())
+    self.assertOnlyIn((3, 12), visitor.minimum_versions())
+
+    self.config.clear_features()
     visitor = self.visit('f"outer {f"inner"}"')
     self.assertTrue(visitor.fstrings())
     self.assertFalse(visitor.fstrings_pep701())

--- a/tests/lang.py
+++ b/tests/lang.py
@@ -98,326 +98,87 @@ class VerminLanguageTests(VerminTest):
       self.assertFalse(visitor.named_expressions())
       self.assertOnlyIn((3, 6), visitor.minimum_versions())
 
+  def assert_self_doc(self, source):
+    visitor = self.visit(source)
+    self.assertTrue(visitor.fstrings())
+    self.assertTrue(visitor.fstrings_self_doc())
+    self.assertOnlyIn((3, 8), visitor.minimum_versions())
+
+  def assert_not_self_doc(self, source):
+    visitor = self.visit(source)
+    self.assertFalse(visitor.fstrings_self_doc())
+
   @VerminTest.skipUnlessVersion(3, 8)
-  def test_fstrings_self_doc(self):
-    enabled = False
-    if enabled:  # pragma: no cover
-      self.config.enable_feature("fstring-self-doc")
-
-      # NOTE: The built-in AST cannot distinguish `f'{a=}'` from `f'a={a}'` because it optimizes
-      # some information away. Therefore, this test will be seen as a self-doc f-string, which is
-      # why fstring self-doc detection has been disabled for now.
-      visitor = self.visit("a = 1\nf'a={a}'")
-      self.assertFalse(visitor.fstrings_self_doc())
-
-      visitor = self.visit("name = 'world'\nf'hello {name=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("name = 'world'\nf'hello={name}'")
-      self.assertFalse(visitor.fstrings_self_doc())
-
-      visitor = self.visit("a = 1\nf'={a}'")
-      self.assertFalse(visitor.fstrings_self_doc())
-
-      visitor = self.visit("a = 1\nf'{a=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("a = 1\nb = 2\nf'={b}={a}'")
-      self.assertFalse(visitor.fstrings_self_doc())
-
-      visitor = self.visit("a = 1\nb = 2\nf'{b=}={a}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{a =}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{ a=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{a= }'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{ a = }'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{1+1=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{1+b=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{a+b=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{a+1=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{a-1=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{a/1=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{a//1=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{a*1=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{not a=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{1 in []=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{1 not in []=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{None is None=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{None is not True=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{10 % 5=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{10 ^ 5=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{10 | 5=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{10 & 5=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{10 ** 5=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{-5=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{+5=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{~5=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{x << y=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{x >> y=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{x @ y=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{a or b=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{a and b=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{(1,2,3)=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{[1,2,3]=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{ {1,2,3}=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{ {1:1, 2:2}=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{[x for x in [1,2,3]]=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{(x for x in [1,2,3])=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{ {x for x in [1,2,3]}=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{ {x:1 for x in [1,2,3]}=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{0==1=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{0<1=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{0>1=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{0<=1=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{0>=1=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{0==1!=2=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{3.14=:10.10}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{3.14=!s:10.10}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{x=!s}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{x=!r}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{x=!a}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{x=:.2f}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{x=!a:^20}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{f\"{3.1415=:.1f}\":*^20}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'alpha a {pi=} w omega'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'''{\n3\n=}'''")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{f(a=4)=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{f(a=\"3=\")=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{C()=!r:*^20}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{user=!s}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{delta.days=:,d}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{user=!s}  {delta.days=:,d}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{delta.days:,d}'")
-      self.assertFalse(visitor.fstrings_self_doc())
-
-      visitor = self.visit("f'{cos(radians(theta)):.3f}'")
-      self.assertFalse(visitor.fstrings_self_doc())
-
-      visitor = self.visit("f'{cos(radians(theta))=:.3f}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'={cos(radians(theta)):.3f}'")
-      self.assertFalse(visitor.fstrings_self_doc())
-
-      visitor = self.visit("f'{theta}  {cos(radians(theta)):.3f}'")
-      self.assertFalse(visitor.fstrings_self_doc())
-
-      visitor = self.visit("f'{cos(radians(theta)):.3f} {theta=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{(a+b)=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{(a+((b-(c*d))/e))=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{d[\"foo\"]=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'i:{i=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{1 if True else 2=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'{(d[a], None) if 42 != 84 else (1,2,3)=}'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
-
-      visitor = self.visit("f'expr={ {x: y for x, y in [(1, 2) ]} = }'")
-      self.assertTrue(visitor.fstrings_self_doc())
-      self.assertOnlyIn((3, 8), visitor.minimum_versions())
+  @VerminTest.parameterized_args([
+    ("a = 1\nf'a={a}'",),
+    ("name = 'world'\nf'hello={name}'",),
+    ("a = 1\nf'={a}'",),
+    ("a = 1\nb = 2\nf'={b}={a}'",),
+    ("f'{x:=10}'",),
+    ("f'hello {name!r}'",),
+    ("f'val={val:.2f}'",),
+    ("f'{(a+b)}={x!r}'",),
+    ("a = 1\nf'{{x={a}}}'",),
+    ("f'{x:.2f}'",),
+  ])
+  def test_self_doc_not_detected(self, source):
+    self.config.enable_feature("fstring-self-doc")
+    self.assert_not_self_doc(source)
+
+  @VerminTest.skipUnlessVersion(3, 8)
+  @VerminTest.parameterized_args([
+    ("a = 1\nf'{a=}'",),
+    ("name = 'world'\nf'hello {name=}'",),
+    ("a = 1\nb = 2\nf'{b=}={a}'",),
+    ("f'{a =}'",),
+    ("f'{ a=}'",),
+    ("f'{a= }'",),
+    ("f'{ a = }'",),
+    ("f'{1+1=}'",),
+    ("f'{a+b=}'",),
+    ("f'{not a=}'",),
+    ("f'{10 % 5=}'",),
+    ("f'{x << y=}'",),
+    ("f'{a or b=}'",),
+    ("f'{(1,2,3)=}'",),
+    ("f'{[1,2,3]=}'",),
+    ("f'{ {1,2,3}=}'",),
+    ("f'{ {1:1, 2:2}=}'",),
+    ("f'{0==1=}'",),
+    ("f'{0<1=}'",),
+    ("f'{0==1!=2=}'",),
+    ("f'{3.14=:10.10}'",),
+    ("f'{3.14=!s:10.10}'",),
+    ("f'{x=!r}'",),
+    ("f'{x=:.2f}'",),
+    ("f'{x=!a:^20}'",),
+    ("f'{d[\"foo\"]=:.2f}'",),
+    ("f'{f\"{3.1415=:.1f}\":*^20}'",),
+    ("f'{f(a=4)=}'",),
+    ("f'{f(a=\"3=\")=}'",),
+    ("f'{C()=!r:*^20}'",),
+    ("f'{delta.days=:,d}'",),
+    ("f'{user=!s}  {delta.days=:,d}'",),
+    ("f'{cos(radians(theta))=:.3f}'",),
+    ("f'{(a+b)=}'",),
+    ("f'{d[\"foo\"]=}'",),
+    ("f'i:{i=}'",),
+    ("f'{1 if True else 2=}'",),
+    ("f'{(d[a], None) if 42 != 84 else (1,2,3)=}'",),
+    ("f'expr={ {x: y for x, y in [(1, 2) ]} = }'",),
+    ("f'''{\na=\n}'''",),
+    ("f\"{x = :.2f}\"",),
+    ("f\"{(x) = :.2f}\"",),
+
+    # Real-world patterns.
+    ("f\"Expected {provider=} to be a class since {provider_kw=} was\"",),
+    ("f\"Disposition param parsing is not linear: {d1=} vs {d2=}\"",),
+    ("f\"overrun because hit {self.max_length=}\"",),
+    ("f'summary: {save_count=} for {len(frames)=}'",),
+  ])
+  def test_self_doc_detected(self, source):
+    self.config.enable_feature("fstring-self-doc")
+    self.assert_self_doc(source)
 
   @VerminTest.skipUnlessVersion(3, 5)
   def test_coroutines_async(self):

--- a/tests/lang.py
+++ b/tests/lang.py
@@ -120,6 +120,7 @@ class VerminLanguageTests(VerminTest):
     ("f'{(a+b)}={x!r}'",),
     ("a = 1\nf'{{x={a}}}'",),
     ("f'{x:.2f}'",),
+    ("x = 'x'\ndef foo(shell):pass\nfoo(shell=f'a={x!r}')",),
   ])
   def test_self_doc_not_detected(self, source):
     self.config.enable_feature("fstring-self-doc")
@@ -175,6 +176,10 @@ class VerminLanguageTests(VerminTest):
     ("f\"Disposition param parsing is not linear: {d1=} vs {d2=}\"",),
     ("f\"overrun because hit {self.max_length=}\"",),
     ("f'summary: {save_count=} for {len(frames)=}'",),
+
+    # kwarg to a user-defined function.
+    ("x = 1\ndef foo(shell):pass\nfoo(shell=f\"{x=}\")",),
+    ("x = 1\ndef foo(position=None, **kw):pass\nfoo(position=1, shell=f\"{x=}\")",),
   ])
   def test_self_doc_detected(self, source):
     self.config.enable_feature("fstring-self-doc")

--- a/tests/lang.py
+++ b/tests/lang.py
@@ -448,6 +448,28 @@ class VerminLanguageTests(VerminTest):
     self.assertTrue(visitor.fstrings_pep701())
     self.assertOnlyIn((3, 12), visitor.minimum_versions())
 
+  @VerminTest.skipUnlessVersion(3, 6)
+  def test_await_in_fstring(self):
+    # From 3.7, `await` may be used in expressions within f-strings.
+    visitor = self.visit("async def f():\n  return f'{await g()}'")
+    self.assertTrue(visitor.fstrings())
+    self.assertTrue(visitor.coroutines())
+    self.assertTrue(visitor.fstrings_await())
+    self.assertOnlyIn((3, 7), visitor.minimum_versions())
+
+    visitor = self.visit("async def f():\n  x = [f'{await g()}']")
+    self.assertTrue(visitor.fstrings_await())
+    self.assertOnlyIn((3, 7), visitor.minimum_versions())
+
+    visitor = self.visit("async def f():\n  await g()")
+    self.assertFalse(visitor.fstrings_await())
+    self.assertOnlyIn((3, 5), visitor.minimum_versions())
+
+    # An f-string without `await` next to one stays at the f-string minimum.
+    visitor = self.visit("async def f():\n  await g()\n  return f'{x}'")
+    self.assertFalse(visitor.fstrings_await())
+    self.assertOnlyIn((3, 6), visitor.minimum_versions())
+
   @VerminTest.skipUnlessVersion(3, 5)
   def test_coroutines_async(self):
     visitor = self.visit("async def func():\n\tpass")

--- a/tests/lang.py
+++ b/tests/lang.py
@@ -266,6 +266,13 @@ class VerminLanguageTests(VerminTest):
     # Comment.
     ('f"{x  # comment\n}"',),
     ('f"{\n# comment\n1+2\n}"',),
+
+    # String literals reusing the outer quote.
+    ('f"abc {a["x"]} def"',),
+    ("f'ab {a['x']} cd'",),
+    ('f"{x:{"ab"}}"',),
+    ('f"{x:{w["y"]}}"',),
+    ('f"{d["k"]=}"',),
   ])
   def test_pep701_detected(self, source):
     self.config.enable_feature("fstring-pep701")
@@ -376,6 +383,18 @@ class VerminLanguageTests(VerminTest):
 
     # Multi-line expression in the triple-quoted trailing part of an implicit concatenation.
     ('s = f"lit {a}" f"""{b\n+ c}"""',),
+
+    # A different quote inside a field is valid since 3.6.
+    ('f"abc {a[\'x\']} def"',),
+    ("f'abc {a[\"x\"]} def'",),
+    ('f"{x:{w[\'y\']}}"',),
+    ('f"{x:>a\'b}"',),
+    ("f'{x:{w[\"y\"]}}'",),
+
+    # Triple-quoted f-strings allow reusing their quote character in a literal.
+    ('f"""abc {a["x"]} def"""',),
+    ('f"""abc {a[\'x\']} def"""',),
+    ("f'''abc {a['x']} def'''",),
   ])
   def test_fstrings_pep701_no_false_positives(self, source):
     self.config.enable_feature("fstring-pep701")
@@ -421,12 +440,13 @@ class VerminLanguageTests(VerminTest):
     self.assertTrue(visitor.fstrings_pep701())
     self.assertOnlyIn((3, 12), visitor.minimum_versions())
 
-    # The double-quoted empty-string self-doc form only parses on 3.12+.
+    # The empty-string self-doc form reuses the outer quote for a literal, so it only parses on
+    # 3.12+ as a same-quote string literal.
     visitor = self.visit('f"{""=}"')
     self.assertTrue(visitor.fstrings())
     self.assertTrue(visitor.fstrings_self_doc())
-    self.assertFalse(visitor.fstrings_pep701())
-    self.assertOnlyIn((3, 8), visitor.minimum_versions())
+    self.assertTrue(visitor.fstrings_pep701())
+    self.assertOnlyIn((3, 12), visitor.minimum_versions())
 
   @VerminTest.skipUnlessVersion(3, 5)
   def test_coroutines_async(self):

--- a/tests/utility.py
+++ b/tests/utility.py
@@ -1,0 +1,54 @@
+from vermin.utility import split_lines
+
+from .testutils import VerminTest
+
+
+class UtilityTests(VerminTest):
+  def test_split_lines_lf(self):
+    lines, offsets = split_lines("a\nb\n")
+    self.assertEqual(["a", "b"], lines)
+    self.assertEqual([0, 2, 4], offsets)
+
+  def test_split_lines_lf_no_trailing_terminator(self):
+    lines, offsets = split_lines("a\nb")
+    self.assertEqual(["a", "b"], lines)
+    self.assertEqual([0, 2, 3], offsets)
+
+  def test_split_lines_crlf(self):
+    lines, offsets = split_lines("a\r\nb\r\n")
+    self.assertEqual(["a", "b"], lines)
+    self.assertEqual([0, 3, 6], offsets)
+
+  def test_split_lines_crlf_mixed(self):
+    lines, offsets = split_lines("a\r\nb\nc\rd")
+    self.assertEqual(["a", "b", "c", "d"], lines)
+    self.assertEqual([0, 3, 5, 7, 8], offsets)
+
+  def test_split_lines_bare_cr(self):
+    lines, offsets = split_lines("a\rb\r")
+    self.assertEqual(["a", "b"], lines)
+    self.assertEqual([0, 2, 4], offsets)
+
+  def test_split_lines_empty(self):
+    lines, offsets = split_lines("")
+    self.assertEqual([], lines)
+    self.assertEqual([0], offsets)
+
+  def test_split_lines_only_terminator(self):
+    self.assertEqual(([""], [0, 1]), split_lines("\n"))
+    self.assertEqual(([""], [0, 2]), split_lines("\r\n"))
+
+  def test_split_lines_consecutive_terminators(self):
+    lines, offsets = split_lines("a\n\n")
+    self.assertEqual(["a", ""], lines)
+    self.assertEqual([0, 2, 3], offsets)
+
+  def test_split_lines_no_terminator(self):
+    lines, offsets = split_lines("single")
+    self.assertEqual(["single"], lines)
+    self.assertEqual([0, 6], offsets)
+
+  def test_split_lines_parser_separators_not_split(self):
+    lines, offsets = split_lines("x = \"\v\f\"\nf\"{y}\"\n")
+    self.assertEqual(["x = \"\v\f\"", "f\"{y}\""], lines)
+    self.assertEqual([0, 9, 16], offsets)

--- a/vermin/arguments.py
+++ b/vermin/arguments.py
@@ -187,10 +187,11 @@ class Arguments:
       print("\n  --no-backport (default)\n"
             "        Use no backports. Clears any backports specified before this.")
       print("\n  [--feature <name>] ...\n"
-            "        Some features are disabled by default due to being unstable:\n{}".
-            format(Features.str(10)))
-      print("\n  --no-feature (default)\n"
-            "        Use no features. Clears any features specified before this.")
+            "        Some features are enabled by default. Others must be\n"
+            "        explicitly enabled:\n{}".format(Features.str(10)))
+      print("\n  --no-feature\n"
+            "        Use no features. Disables all features, including those\n"
+            "        that are enabled by default.")
 
   def parse(self, config, detect_folder=None):
     assert config is not None

--- a/vermin/config.py
+++ b/vermin/config.py
@@ -29,7 +29,7 @@ class Config:
     self.__exclusion_regex = set()
     self.__make_paths_absolute = True
     self.__backports = set()
-    self.__features = set()
+    self.__features = Features.defaults()
     self.__targets = []
     self.__eval_annotations = False
     self.__only_show_violations = False

--- a/vermin/features.py
+++ b/vermin/features.py
@@ -1,14 +1,15 @@
 from .utility import format_title_descs
 
+DEFAULT_FEATURES = ("fstring-self-doc", "fstring-pep701")
+
 FEATURES = (
   ("fstring-self-doc", [
-    "[Unstable] Detect self-documenting fstrings. Can in",
-    "some cases wrongly report fstrings as self-documenting."
+    "Detect self-documenting fstrings. Enabled by default.",
   ]),
   ("fstring-pep701", [
-    "[Unstable] Detect PEP 701 f-string features (3.12+).",
-    "Same-quote nesting and multi-line expressions.",
-    "Requires running on Python 3.12+."
+    "Detect PEP 701 f-string features (3.12+): same-quote",
+    "nesting and multi-line expressions. Requires running on",
+    "Python 3.12+. Enabled by default."
   ]),
   ("union-types", [
     "[Unstable] Detect union types `X | Y`. Can in some cases",
@@ -17,6 +18,10 @@ FEATURES = (
 )
 
 class Features:
+  @staticmethod
+  def defaults():
+    return set(DEFAULT_FEATURES)
+
   @staticmethod
   def str(indent=0):
     return format_title_descs(FEATURES, Features.features(), indent)

--- a/vermin/features.py
+++ b/vermin/features.py
@@ -5,6 +5,11 @@ FEATURES = (
     "[Unstable] Detect self-documenting fstrings. Can in",
     "some cases wrongly report fstrings as self-documenting."
   ]),
+  ("fstring-pep701", [
+    "[Unstable] Detect PEP 701 f-string features (3.12+).",
+    "Same-quote nesting and multi-line expressions.",
+    "Requires running on Python 3.12+."
+  ]),
   ("union-types", [
     "[Unstable] Detect union types `X | Y`. Can in some cases",
     "wrongly report union types due to having to employ heuristics."

--- a/vermin/fstring_detector.py
+++ b/vermin/fstring_detector.py
@@ -48,9 +48,8 @@ class FStringDetector:
 
   def _codepoint_length(self, lines, start_lineno, start_col_offset,
                         end_lineno, end_col_offset):
-    src_len = len(self._source)
-    start_off = self._span_offset(lines, start_lineno, start_col_offset, src_len)
-    end_off = self._span_offset(lines, end_lineno, end_col_offset, src_len)
+    start_off = self._span_offset(lines, start_lineno, start_col_offset)
+    end_off = self._span_offset(lines, end_lineno, end_col_offset)
     if start_off is None or end_off is None:
       return 0
     return max(0, end_off - start_off)
@@ -80,8 +79,8 @@ class FStringDetector:
     """Confirm self-doc by locating each `{..}` region in the source."""
     source = self._source
     lines = self._lines
-    start = self._span_offset(lines, node.lineno, node.col_offset, len(source))
-    end = self._span_offset(lines, node.end_lineno, node.end_col_offset, len(source))
+    start = self._span_offset(lines, node.lineno, node.col_offset)
+    end = self._span_offset(lines, node.end_lineno, node.end_col_offset)
     if start is None or end is None:
       return False
 
@@ -293,14 +292,14 @@ class FStringDetector:
 
     # Map the byte-based span-start position to a code-point source offset.
     src_len = len(source)
-    start = self._span_offset(lines, node.lineno, node.col_offset, src_len)
+    start = self._span_offset(lines, node.lineno, node.col_offset)
     if start is None:
       return None
 
     # Use end-of-source as the span end when the node has no end column.
     end = src_len
     if hasattr(node, "end_col_offset"):
-      end = self._span_offset(lines, node.end_lineno, node.end_col_offset, src_len)
+      end = self._span_offset(lines, node.end_lineno, node.end_col_offset)
       if end is None:
         return None
 
@@ -311,7 +310,7 @@ class FStringDetector:
       if not isinstance(val, ast.FormattedValue):
         continue
       if hasattr(val, "lineno") and hasattr(val, "col_offset"):
-        offset = self._span_offset(lines, val.lineno, val.col_offset, src_len)
+        offset = self._span_offset(lines, val.lineno, val.col_offset)
         if offset is None:
           return None
         bound = offset
@@ -347,11 +346,11 @@ class FStringDetector:
       pos += 1
     return None
 
-  def _span_offset(self, lines, lineno, col_offset, src_len):
+  def _span_offset(self, lines, lineno, col_offset):
     """Return the source offset of a code-point line/column position, or None."""
-    if lineno - 1 >= src_len:
+    if not lines or lineno < 1 or lineno > len(lines):
       return None
-    return self._line_offsets[lineno - 1] + self._codepoint_col(lines, lineno, col_offset)
+    return self._line_offsets[lineno - 1] + self._codepoint_col(lines, lineno, max(0, col_offset))
 
   def _skip_string(self, source, pos, bound, src_len):
     """Skip a plain string literal starting at the quote at `pos` and return the offset past it."""
@@ -391,8 +390,8 @@ class FStringDetector:
     if not hasattr(node, "end_col_offset"):
       return contexts, default
 
-    start = self._span_offset(lines, node.lineno, node.col_offset, src_len)
-    end = self._span_offset(lines, node.end_lineno, node.end_col_offset, src_len)
+    start = self._span_offset(lines, node.lineno, node.col_offset)
+    end = self._span_offset(lines, node.end_lineno, node.end_col_offset)
     if start is None or end is None:
       return contexts, default
 
@@ -447,7 +446,7 @@ class FStringDetector:
     col = getattr(val, "col_offset", None)
     if lineno is None or col is None:
       return default_context
-    offset = self._span_offset(self._lines, lineno, col, len(self._source))
+    offset = self._span_offset(self._lines, lineno, col)
     field_ctx = contexts.get(offset)
     return default_context if field_ctx is None else field_ctx
 
@@ -557,8 +556,8 @@ class FStringDetector:
       return False
 
     src_len = len(source)
-    start = self._span_offset(lines, node.lineno, node.col_offset, src_len)
-    end = self._span_offset(lines, node.end_lineno, node.end_col_offset, src_len)
+    start = self._span_offset(lines, node.lineno, node.col_offset)
+    end = self._span_offset(lines, node.end_lineno, node.end_col_offset)
     if start is None or end is None or end <= start + 2:
       return False
 
@@ -648,16 +647,16 @@ class FStringDetector:
       return False
 
     src_len = len(source)
-    start = self._span_offset(lines, node.lineno, node.col_offset, src_len)
+    start = self._span_offset(lines, node.lineno, node.col_offset)
     if start is None:
       return False
 
     # Bound the scan by the format-spec `:` when present, else the closing `}`.
     spec = node.format_spec if hasattr(node, "format_spec") else None
     if spec is not None and getattr(spec, "lineno", None) is not None:
-      end = self._span_offset(lines, spec.lineno, spec.col_offset, src_len)
+      end = self._span_offset(lines, spec.lineno, spec.col_offset)
     else:
-      end = self._span_offset(lines, node.end_lineno, node.end_col_offset, src_len)
+      end = self._span_offset(lines, node.end_lineno, node.end_col_offset)
       if end is not None and end > start and source[end - 1] == CLOSE_BRACE:
         end -= 1
     if end is None or end <= start:

--- a/vermin/fstring_detector.py
+++ b/vermin/fstring_detector.py
@@ -85,12 +85,11 @@ class FStringDetector:
     if start is None or end is None:
       return False
 
-    # Skip the f-string prefix and the opening quote.
-    pos = start
-    while pos < end and source[pos].lower() in FSTRING_PREFIX_CHARS:
-      pos += 1
-    if pos < end and source[pos] in STRING_QUOTE_CHARS:
-      pos += 1
+    # Locate the first f-string literal in the fused span. Implicit concat can merge a leading plain
+    # string part, whose literal braces would otherwise misdirect the `{`-anchor.
+    pos = self._fstring_opener_end(source, start, end, start)
+    if pos is None:
+      return False
 
     for idx, val in enumerate(node.values):
       if not isinstance(val, ast.FormattedValue):
@@ -247,6 +246,36 @@ class FStringDetector:
 
       if self._has_pep701_comment(val, lines):
         return "comment"
+    return None
+
+  def _fstring_opener_end(self, source, pos, bound, lower_bound):
+    """Return the offset just past the opening quote of the first f-string literal in `[pos,
+    bound)`, skipping plain strings, comments, and non-f prefixes, or None if there is no f-string.
+    """
+    while pos < bound:
+      ch = source[pos]
+
+      if ch in STRING_QUOTE_CHARS:
+        if self._match_fstring_quote(source, pos, lower_bound) is None:
+          next_pos = self._skip_string(source, pos, bound, len(source))
+          if next_pos >= bound:
+            # No well-formed plain literal within bounds. Advance past the lone quote and keep
+            # scanning so the `{`-anchor still finds the fields.
+            pos += SINGLE_QUOTE_LEN
+            continue
+          pos = next_pos
+          continue
+
+        # F-string opener found. Return just past its quote(s).
+        pos += (TRIPLE_QUOTE_LEN if source.startswith(ch * TRIPLE_QUOTE_LEN, pos)
+                else SINGLE_QUOTE_LEN)
+        return pos
+
+      if ch == HASH:
+        pos = self._skip_comment(source, pos, bound)
+        continue
+
+      pos += 1
     return None
 
   def _read_fstring_token(self, node, lines):

--- a/vermin/fstring_detector.py
+++ b/vermin/fstring_detector.py
@@ -673,7 +673,7 @@ class FStringDetector:
     while pos < field_len:
       ch = field[pos]
       if ch in STRING_QUOTE_CHARS:
-        pos = self._skip_string(source, start + pos, start + end, src_len) - start
+        pos = self._skip_string(source, start + pos, end, src_len) - start
         continue
       if ch == HASH:
         return True

--- a/vermin/fstring_detector.py
+++ b/vermin/fstring_detector.py
@@ -1,0 +1,614 @@
+import ast
+
+from .utility import split_lines
+
+
+BACKSLASH = "\\"
+HASH = "#"
+FSTRING_PREFIX_CHARS = "furb"
+STRING_QUOTE_CHARS = "\"'"
+NEWLINE = "\n"
+OPEN_BRACE = "{"
+CLOSE_BRACE = "}"
+DOUBLE_BRACE = "{{"
+TRIPLE_QUOTE_LEN = 3
+SINGLE_QUOTE_LEN = 1
+FSTRING_FLAG = "f"
+FSTRING_TOKEN_PREFIX_CHARS = "rf"  # nosec
+UNICODE_NAME_ESCAPE = BACKSLASH + "N"
+CLOSING_TRAILERS = ")]"
+WS_AND_NEWLINES = " \t\r" + NEWLINE
+WS_AND_TRAILERS = WS_AND_NEWLINES + CLOSING_TRAILERS
+SELF_DOC_MARKER = "="
+SELF_DOC_FOLLOW_CHARS = "!:`}"
+REPR_CONVERSION = ord("r")
+
+
+class FStringDetector:
+  def __init__(self, source):
+    self._source = source
+    if source is None:
+      self._lines = None
+      self._line_offsets = [0]
+    else:
+      self._lines, self._line_offsets = split_lines(source)
+
+  def _codepoint_col(self, lines, lineno, col_offset):
+    """Convert an AST byte-based column offset to a code-point column offset. CPython reports
+    `col_offset`/`end_col_offset` as byte offsets into the UTF-8 encoded source, while slicing
+    operates on code-point strings, so the two only differ after non-ASCII text on the same line.
+    """
+    if not lines or lineno < 1 or lineno > len(lines) or col_offset <= 0:
+      return 0
+    line = lines[lineno - 1]
+    try:
+      return len(line.encode("utf-8")[:col_offset].decode("utf-8"))
+    except UnicodeDecodeError:
+      return len(line)
+
+  def _codepoint_length(self, lines, start_lineno, start_col_offset,
+                        end_lineno, end_col_offset):
+    src_len = len(self._source)
+    start_off = self._span_offset(lines, start_lineno, start_col_offset, src_len)
+    end_off = self._span_offset(lines, end_lineno, end_col_offset, src_len)
+    if start_off is None or end_off is None:
+      return 0
+    return max(0, end_off - start_off)
+
+  def is_self_doc(self, node):
+    if not hasattr(node, "values") or self._source is None:
+      return False
+    values = node.values
+    for idx, value in enumerate(values):
+      if isinstance(value, ast.FormattedValue) and self._is_fstring_self_doc_candidate(values, idx):
+        return self._self_doc_source_walk(node)
+    return False
+
+  def _is_fstring_self_doc_candidate(self, values, index):
+    """Whether the FormattedValue at `index` may be self-documenting. A `{expr=}` field carries
+    conversion 114 (`ord("r")`), while a `{literal=}` field, like `{3.14=:..}`, folds with
+    conversion -1 and ends the preceding Constant's text in `=`.
+    """
+    val = values[index]
+    if val.conversion == REPR_CONVERSION:
+      return True
+    return index > 0 and isinstance(values[index - 1], ast.Constant) and \
+      isinstance(values[index - 1].value, str) and \
+      values[index - 1].value.rstrip().endswith(SELF_DOC_MARKER)
+
+  def _self_doc_source_walk(self, node):
+    """Confirm self-doc by locating each `{..}` region in the source."""
+    source = self._source
+    lines = self._lines
+    start = self._span_offset(lines, node.lineno, node.col_offset, len(source))
+    end = self._span_offset(lines, node.end_lineno, node.end_col_offset, len(source))
+    if start is None or end is None:
+      return False
+
+    # Skip the f-string prefix and the opening quote.
+    pos = start
+    while pos < end and source[pos].lower() in FSTRING_PREFIX_CHARS:
+      pos += 1
+    if pos < end and source[pos] in STRING_QUOTE_CHARS:
+      pos += 1
+
+    for idx, val in enumerate(node.values):
+      if not isinstance(val, ast.FormattedValue):
+        continue
+
+      # Find the next non-escaped opening brace.
+      while pos < end:
+        if source[pos] == OPEN_BRACE:
+          # Skip escaped `{{`.
+          if source.startswith(DOUBLE_BRACE, pos):
+            pos += len(DOUBLE_BRACE)
+            continue
+
+          # Skip to the closing brace of a `\N{..}` unicode name or a `\{` escaped literal.
+          if (pos >= start + len(UNICODE_NAME_ESCAPE) and
+              source[pos - len(UNICODE_NAME_ESCAPE):pos] == UNICODE_NAME_ESCAPE) or \
+             (pos > start and source[pos - 1] == BACKSLASH):
+            close = source.find(CLOSE_BRACE, pos, end)
+            pos = close + 1 if close != -1 else end
+            continue
+
+          break  # Actual opening brace found.
+        pos += 1
+      if pos >= end:
+        break
+
+      # Skip non-candidates and consume region.
+      if not self._is_fstring_self_doc_candidate(node.values, idx):
+        close = source.find(CLOSE_BRACE, pos, end)
+        if close == -1:
+          break
+        pos = close + 1
+        continue
+
+      # Nested f-strings get bogus positions on Python 3.8 because inner tokens are pinned to the
+      # opening quote, so the `{`-anchor cannot locate their fields. A self-doc fold whose text
+      # appears verbatim in the source with a `{` directly before it is self-locating, its trailing
+      # `=` the marker.
+      if idx > 0 and isinstance(node.values[idx - 1], ast.Constant) and \
+         isinstance(node.values[idx - 1].value, str) and \
+         node.values[idx - 1].value.rstrip().endswith(SELF_DOC_MARKER) and \
+         not node.values[idx - 1].value.startswith(OPEN_BRACE):
+        const_text = node.values[idx - 1].value
+        match = start - 1
+        while True:
+          match = source.find(const_text, match + 1, end)
+          if match == -1:
+            break
+
+          # Unescaped `{` directly before (not `{{`), and a valid self-doc follow char after `=`.
+          after = match + len(const_text)
+          if match - 1 >= start and source[match - 1] == OPEN_BRACE and \
+             not (match - 2 >= start and source[match - 2] == OPEN_BRACE) and \
+             (after >= end or source[after] in SELF_DOC_FOLLOW_CHARS):
+            return True
+
+      # Position is lost on 3.8 but the length survives, so the end is derivable.
+      if not hasattr(val.value, "end_col_offset") or val.value.end_col_offset is None:
+        return False
+
+      # Skip leading whitespace in the field body.
+      body = pos + 1
+      while body < end and source[body] in WS_AND_NEWLINES:
+        body += 1
+
+      # Measure the expression via AST positions, then skip closing trailers (parens/brackets).
+      length = self._codepoint_length(lines, val.value.lineno, val.value.col_offset,
+                                      val.value.end_lineno, val.value.end_col_offset)
+      expr_end = body + length
+      while expr_end < end and source[expr_end] in CLOSING_TRAILERS:
+        expr_end += 1
+
+      # Skip trailing whitespace and look for the `=` self-doc marker.
+      probe = expr_end
+      while probe < end and source[probe] in WS_AND_NEWLINES:
+        probe += 1
+      if probe < end and source[probe] == SELF_DOC_MARKER:
+        return True
+
+      # Grouping-paren inclusion differs across node types and versions, so the span may land before
+      # the actual end. Probe one char further on.
+      if not (probe < end and source[probe] in SELF_DOC_FOLLOW_CHARS) and \
+         expr_end + 1 < end:
+        probe = expr_end + 1
+        while probe < end and source[probe] in WS_AND_TRAILERS:
+          probe += 1
+        if expr_end + 1 < probe < end and source[probe] == SELF_DOC_MARKER:
+          return True
+
+      close = source.find(CLOSE_BRACE, body, end)
+      if close == -1:
+        break
+      pos = close + 1
+    return False
+
+  def pep701_violation(self, node):
+    """Return the first PEP 701 construct the JoinedStr `node` triggers, or None. All four are
+    `SyntaxError` before 3.12.
+    """
+    if self._source is None:
+      return None
+    if not hasattr(node, "values") or not hasattr(node, "end_lineno"):
+      return None
+
+    # Pre-3.12 parsers pin internal `FormattedValue` positions to the whole span, so the scan bound
+    # collapses onto the span start and no quote can be read. The analysis is skipped on such trees.
+    lines = self._lines
+    if self._read_fstring_token(node, lines) is None:
+      return None
+    contexts, default_context = self._build_field_contexts(node, lines)
+
+    for val in node.values:
+      if not isinstance(val, ast.FormattedValue):
+        continue
+
+      outer = self._resolve_field_context(val, contexts, default_context)
+      if outer is None:
+        continue
+      outer_quote, outer_triple = outer
+
+      # Check expression spanning lines in a single/double-quoted f-string. Triple-quoted f-strings
+      # allow newlines natively (3.6+), and implicit concatenation that merges a triple-quoted part
+      # (which the parser collapses, losing the triple-quote info in the AST) is excluded too.
+      if not outer_triple and hasattr(val, "end_lineno") and \
+         val.end_lineno is not None and hasattr(val, "lineno") and \
+         val.end_lineno > val.lineno:
+        return "multi_line"
+
+      # Check same-quote nesting. A triple-quoted outer f-string allows a nested single-occurrence
+      # inner quote natively, but nested triple-quote f-strings using the same character require
+      # 3.12+.
+      for inner_js in self._walk_joined_strs(val):
+        if inner_js.lineno == node.lineno and \
+           inner_js.col_offset == node.col_offset:
+          # Pre-3.12 parsers pin inner `JoinedStr` nodes to the outer quote, which would falsely
+          # read as same-quote nesting with itself.
+          continue
+
+        inner = self._read_fstring_token(inner_js, lines)
+        if inner is None or inner[0] != outer_quote:
+          continue
+        if not outer_triple or inner[1]:
+          return "nested_same_quote"
+
+      if self._has_pep701_backslash(val, lines):
+        return "backslash"
+
+      if self._has_pep701_comment(val, lines):
+        return "comment"
+    return None
+
+  def _read_fstring_token(self, node, lines):
+    """Return `(quote, is_triple)` of the f-string opening at `node`'s span, or None. On 3.12+
+    implicit-concat, `col_offset` points at the leading part and raw prefixes at the `f`, so the
+    opener is scanned forward to the first f-string literal. This also stops a nested same-quote
+    literal like `f"{f'x'}"` from being misread as the opener.
+    """
+    source = self._source
+    if source is None or lines is None or not lines:
+      return None
+    if not hasattr(node, "lineno") or not hasattr(node, "end_lineno") or \
+       not hasattr(node, "col_offset"):
+      return None
+
+    # Map the byte-based span-start position to a code-point source offset.
+    src_len = len(source)
+    start = self._span_offset(lines, node.lineno, node.col_offset, src_len)
+    if start is None:
+      return None
+
+    # Use end-of-source as the span end when the node has no end column.
+    end = src_len
+    if hasattr(node, "end_col_offset"):
+      end = self._span_offset(lines, node.end_lineno, node.end_col_offset, src_len)
+      if end is None:
+        return None
+
+    # Stop scanning at the first field to avoid misreading a nested same-quote literal as the
+    # opener.
+    bound = end
+    for val in node.values:
+      if not isinstance(val, ast.FormattedValue):
+        continue
+      if hasattr(val, "lineno") and hasattr(val, "col_offset"):
+        offset = self._span_offset(lines, val.lineno, val.col_offset, src_len)
+        if offset is None:
+          return None
+        bound = offset
+      break
+
+    # Skip plain strings, comments, and non-f prefix tokens to reach the f-string opener.
+    pos = start
+    while pos < bound:
+      ch = source[pos]
+
+      if ch in STRING_QUOTE_CHARS:
+        pos = self._skip_string(source, pos, bound, src_len)
+        continue
+
+      if ch == HASH:
+        pos = self._skip_comment(source, pos, bound)
+        continue
+
+      if ch.lower() in FSTRING_TOKEN_PREFIX_CHARS:
+        prefix_end = pos
+        while prefix_end < bound and source[prefix_end].lower() in FSTRING_TOKEN_PREFIX_CHARS:
+          prefix_end += 1
+        if prefix_end < bound and source[prefix_end] in STRING_QUOTE_CHARS:
+          if FSTRING_FLAG in source[pos:prefix_end].lower():
+            quote = source[prefix_end]
+            is_triple = source.startswith(quote * TRIPLE_QUOTE_LEN, prefix_end)
+            return (quote, is_triple)  # f-string opener found.
+
+          # Skip plain non-fstring, like `r"lit"`.
+          pos = self._skip_string(source, prefix_end, bound, src_len)
+          continue
+
+      pos += 1
+    return None
+
+  def _span_offset(self, lines, lineno, col_offset, src_len):
+    """Return the source offset of a code-point line/column position, or None."""
+    if lineno - 1 >= src_len:
+      return None
+    return self._line_offsets[lineno - 1] + self._codepoint_col(lines, lineno, col_offset)
+
+  def _skip_string(self, source, pos, bound, src_len):
+    """Skip a plain string literal starting at the quote at `pos` and return the offset past it."""
+    quote = source[pos]
+    is_triple = source.startswith(quote * TRIPLE_QUOTE_LEN, pos)
+    scan = pos + (TRIPLE_QUOTE_LEN if is_triple else SINGLE_QUOTE_LEN)
+    while scan < bound and scan < src_len:
+      ch = source[scan]
+      if ch == BACKSLASH:
+        scan += 2
+      elif is_triple:
+        if source.startswith(quote * TRIPLE_QUOTE_LEN, scan):
+          return scan + TRIPLE_QUOTE_LEN  # Closing triple quote found.
+        scan += 1
+      elif ch == quote:
+        return scan + SINGLE_QUOTE_LEN
+      else:
+        scan += 1
+    return min(bound, src_len)
+
+  def _skip_comment(self, source, pos, bound):
+    """Skip `#` comment to the end of its line and return the offset past the newline or `bound`."""
+    nl_pos = source.find(NEWLINE, pos, bound)
+    return bound if nl_pos == -1 else nl_pos + 1
+
+  def _build_field_contexts(self, node, lines):
+    """Map each top-level replacement-field `{` offset to the `(quote, is_triple)` of the f-string
+    literal that contains it, plus a default context (the first f-string token) used when a field
+    cannot be attributed. The source is scanned forward over the whole fused span, so leading plain
+    strings and `#` comments between implicitly-concatenated parts are skipped before a part's quote
+    is read, and single- and triple-quoted parts each contribute their own context.
+    """
+    source = self._source
+    src_len = len(source)
+    contexts = {}
+    default = None
+    if not hasattr(node, "end_col_offset"):
+      return contexts, default
+
+    start = self._span_offset(lines, node.lineno, node.col_offset, src_len)
+    end = self._span_offset(lines, node.end_lineno, node.end_col_offset, src_len)
+    if start is None or end is None:
+      return contexts, default
+
+    # Scan the fused span, attributing each `{` to the f-string literal that contains it.
+    pos = start
+    while pos < end:
+      ch = source[pos]
+
+      # Record f-string literals' quote and tripleness in their context.
+      if ch in STRING_QUOTE_CHARS:
+        fstr = self._match_fstring_quote(source, pos, start)
+        if fstr is None:
+          pos = self._skip_string(source, pos, end, src_len)
+          continue
+        quote, is_triple = fstr
+        context = (quote, is_triple)
+        if default is None:
+          default = context
+        pos = self._fstring_body_end(source, pos, end, quote, is_triple, context, contexts)
+        continue
+
+      # Skip escaped/nested braces and map each field to its context.
+      if ch == OPEN_BRACE:
+        if source.startswith(DOUBLE_BRACE, pos):
+          pos += len(DOUBLE_BRACE)  # Escaped brace in a literal.
+          continue
+
+        # A `\N{` unicode name or a `\{` escaped literal is not a replacement field.
+        if (pos >= start + len(UNICODE_NAME_ESCAPE) and
+            source[pos - len(UNICODE_NAME_ESCAPE):pos] == UNICODE_NAME_ESCAPE) or \
+           (pos > start and source[pos - 1] == BACKSLASH):
+          close = source.find(CLOSE_BRACE, pos, end)
+          pos = close + 1 if close != -1 else end
+          continue
+
+        if default is not None:
+          contexts[pos] = default
+        pos = self._field_end(source, pos + 1, end)
+        continue
+
+      # Skip comments between concatenated parts to the end of the line.
+      if ch == HASH:
+        pos = self._skip_comment(source, pos, end)
+        continue
+
+      pos += 1
+    return contexts, default
+
+  def _resolve_field_context(self, val, contexts, default_context):
+    """Return the `(quote, is_triple)` context of the f-string literal enclosing a field."""
+    lineno = getattr(val, "lineno", None)
+    col = getattr(val, "col_offset", None)
+    if lineno is None or col is None:
+      return default_context
+    offset = self._span_offset(self._lines, lineno, col, len(self._source))
+    field_ctx = contexts.get(offset)
+    return default_context if field_ctx is None else field_ctx
+
+  def _match_fstring_quote(self, source, pos, lower_bound):
+    """Return the quote and tripleness if `source[pos]` opens an f-string literal, else None."""
+    prefix_start = pos - 1
+    while prefix_start >= lower_bound and source[prefix_start].lower() in FSTRING_PREFIX_CHARS:
+      prefix_start -= 1
+    if FSTRING_FLAG not in source[prefix_start + 1:pos].lower():
+      return None
+    return (source[pos], source.startswith(source[pos] * TRIPLE_QUOTE_LEN, pos))
+
+  def _fstring_body_end(self, source, pos, end, quote, is_triple, context, contexts):
+    """Scan one f-string literal's body, starting at its opening quote at `pos`, and return the
+    offset just past its closing quote. Replacement fields directly under the literal are mapped to
+    `context` in `contexts` when that mapping is wanted.
+    """
+    pos += TRIPLE_QUOTE_LEN if is_triple else SINGLE_QUOTE_LEN
+    while pos < end:
+      ch = source[pos]
+
+      # Skip escaped character.
+      if ch == BACKSLASH:
+        pos += 2
+        continue
+
+      if ch == OPEN_BRACE:
+        # Skip escaped `{{`.
+        if source.startswith(DOUBLE_BRACE, pos):
+          pos += len(DOUBLE_BRACE)
+          continue
+
+        # Skip `\N{..}` unicode name escape.
+        if pos >= len(UNICODE_NAME_ESCAPE) and \
+           source[pos - len(UNICODE_NAME_ESCAPE):pos] == UNICODE_NAME_ESCAPE:
+          close = source.find(CLOSE_BRACE, pos, end)
+          pos = close + 1 if close != -1 else end
+          continue
+
+        # Skip a backslash-escaped nested brace.
+        if pos > 0 and source[pos - 1] == BACKSLASH:
+          pos += 1
+          continue
+
+        if contexts is not None:
+          contexts[pos] = context
+        pos = self._field_end(source, pos + 1, end)
+        continue
+
+      # Closing triple quote found.
+      if is_triple:
+        if source.startswith(quote * TRIPLE_QUOTE_LEN, pos):
+          return pos + TRIPLE_QUOTE_LEN
+
+      # Closing single quote found.
+      elif ch == quote:
+        return pos + SINGLE_QUOTE_LEN
+
+      pos += 1
+    return end
+
+  def _field_end(self, source, pos, end):
+    """Scan a replacement field's expression, just after its `{`, and return the offset just past
+    the matching `}`. Braces, strings, escapes, and nested f-strings inside the expression are
+    skipped, so the enclosing brace is found even when a nested f-string reuses the same quote.
+    """
+    depth = 1
+    while pos < end:
+      ch = source[pos]
+      if ch in STRING_QUOTE_CHARS:
+        fstr = self._match_fstring_quote(source, pos, 0)
+        if fstr is None:
+          pos = self._skip_string(source, pos, end, len(source))
+          continue
+        quote, is_triple = fstr
+        pos = self._fstring_body_end(source, pos, end, quote, is_triple, None, None)
+        continue
+
+      # Skip escaped character.
+      if ch == BACKSLASH:
+        pos += 2
+        continue
+
+      # Nested field/brace.
+      if ch == OPEN_BRACE:
+        depth += 1
+        pos += 1
+        continue
+
+      if ch == CLOSE_BRACE:
+        depth -= 1
+        if depth == 0:
+          return pos + 1  # Matching closing brace found.
+
+      pos += 1
+    return end
+
+  def _walk_joined_strs(self, node):
+    for child in ast.iter_child_nodes(node):
+      if isinstance(child, ast.JoinedStr):
+        yield child
+      yield from self._walk_joined_strs(child)  # novermin
+
+  def _has_pep701_backslash(self, node, lines):
+    """Whether a FormattedValue expression contains a backslash (PEP 701). Before 3.12, backslashes
+    were forbidden in f-string expressions.
+    """
+    source = self._source
+    if source is None or lines is None:
+      return False
+
+    # If the expression ends on a different line than the replacement field, scan the source between
+    # them for a line-continuation backslash.
+    expr = node.value
+    if node.end_lineno != expr.end_lineno:
+      expr_line = expr.end_lineno
+      expr_col = self._codepoint_col(lines, expr.end_lineno, expr.end_col_offset)
+      field_line = node.end_lineno
+      field_col = self._codepoint_col(lines, node.end_lineno, node.end_col_offset)
+      gap_parts = []
+      if expr_line - 1 < len(lines):
+        gap_parts.append(lines[expr_line - 1][expr_col:])
+      for line_no in range(expr_line, field_line - 1):
+        if line_no < len(lines):
+          gap_parts.append(lines[line_no])
+      if field_line - 1 < len(lines):
+        gap_parts.append(lines[field_line - 1][:field_col])
+      if any(BACKSLASH in part for part in gap_parts):
+        return True
+
+    # Escape sequence in a string literal within the expression. The single-line guard makes the
+    # ASCII line slice a complete and cheap check, skipping `ast.get_source_segment()`.
+    if expr.lineno == expr.end_lineno:
+      line = lines[expr.lineno - 1]
+      lo = self._codepoint_col(lines, expr.lineno, expr.col_offset)
+      hi = self._codepoint_col(lines, expr.lineno, expr.end_col_offset)
+      if BACKSLASH not in line[lo:hi]:
+        return False
+
+    # Tokenize the full expression source to confirm a backslash. Only reachable on Python 3.8+
+    # because that's when `ast.get_source_segment()` was added
+    if hasattr(ast, "get_source_segment"):
+      expr_src = ast.get_source_segment(source, expr)  # novermin
+      if expr_src and BACKSLASH in expr_src:
+        import tokenize as _tokenize  # novermin, pylint: disable=import-outside-toplevel
+        import io as _io  # novermin, pylint: disable=import-outside-toplevel
+        try:
+          tokens = list(_tokenize.generate_tokens(
+            _io.StringIO(expr_src).readline))
+          for tok in tokens:
+            if tok.type == _tokenize.STRING and BACKSLASH in tok.string:
+              return True
+        except _tokenize.TokenError:
+          pass
+    return False
+
+  def _has_pep701_comment(self, node, lines):
+    """Whether a replacement field contains a comment (PEP 701). Before 3.12, comments were
+    forbidden inside f-string expressions. The parser strips them, so the region between the opening
+    `{` and the top-level format spec's `:`, or the closing `}`, is scanned for `#` characters that
+    are outside string literals. A `#` in the format spec itself, after the `:`, is spec filler text
+    and is valid since 3.6.
+    """
+    source = self._source
+    if source is None or lines is None or not hasattr(node, "end_lineno"):
+      return False
+
+    src_len = len(source)
+    start = self._span_offset(lines, node.lineno, node.col_offset, src_len)
+    if start is None:
+      return False
+
+    # Bound the scan by the format-spec `:` when present, else the closing `}`.
+    spec = node.format_spec if hasattr(node, "format_spec") else None
+    if spec is not None and getattr(spec, "lineno", None) is not None:
+      end = self._span_offset(lines, spec.lineno, spec.col_offset, src_len)
+    else:
+      end = self._span_offset(lines, node.end_lineno, node.end_col_offset, src_len)
+      if end is not None and end > start and source[end - 1] == CLOSE_BRACE:
+        end -= 1
+    if end is None or end <= start:
+      return False
+
+    # Skip the scan below when the region contains no `#` at all.
+    field = source[start:end]
+    if HASH not in field:
+      return False
+
+    # Scan the region for `#` outside string literals.
+    field_len = len(field)
+    pos = 0
+    while pos < field_len:
+      ch = field[pos]
+      if ch in STRING_QUOTE_CHARS:
+        pos = self._skip_string(source, start + pos, start + end, src_len) - start
+        continue
+      if ch == HASH:
+        return True
+      pos += 1
+    return False

--- a/vermin/fstring_detector.py
+++ b/vermin/fstring_detector.py
@@ -187,7 +187,7 @@ class FStringDetector:
     return False
 
   def pep701_violation(self, node):
-    """Return the first PEP 701 construct the JoinedStr `node` triggers, or None. All four are
+    """Return the first PEP 701 construct the JoinedStr `node` triggers, or None. All five are
     `SyntaxError` before 3.12.
     """
     if self._source is None:
@@ -235,8 +235,15 @@ class FStringDetector:
         if not outer_triple or inner[1]:
           return "nested_same_quote"
 
+      # A string literal reusing the outer quote inside a field is only legal from 3.12. A
+      # triple-quoted f-string natively allows the single-character reuse, so only single/double
+      # quotes trigger this. The backslash check is ordered first so escaped same-quote literals
+      # keep their backslash label.
       if self._has_pep701_backslash(val, lines):
         return "backslash"
+
+      if not outer_triple and self._has_same_quote_string(val, outer_quote):
+        return "same_quote_string"
 
       if self._has_pep701_comment(val, lines):
         return "comment"
@@ -508,6 +515,38 @@ class FStringDetector:
 
       pos += 1
     return end
+
+  def _has_same_quote_string(self, node, outer_quote):
+    """Whether a replacement field contains a string literal reusing the outer quote. Reusing the
+    quote character only became legal within a field in 3.12, so the whole field body, expression
+    and format spec, is scanned for a bare outer-quote character.
+    """
+    source = self._source
+    lines = self._lines
+    if source is None or lines is None or not hasattr(node, "end_lineno") or \
+       not hasattr(node, "end_col_offset"):
+      return False
+
+    src_len = len(source)
+    start = self._span_offset(lines, node.lineno, node.col_offset, src_len)
+    end = self._span_offset(lines, node.end_lineno, node.end_col_offset, src_len)
+    if start is None or end is None or end <= start + 2:
+      return False
+
+    # Exclude the enclosing braces, bounding the scan to the field body.
+    if end > start and source[end - 1] == CLOSE_BRACE:
+      end -= 1
+
+    pos = start + 1
+    while pos < end:
+      ch = source[pos]
+      if ch == outer_quote:
+        return True
+      if ch in STRING_QUOTE_CHARS:
+        pos = self._skip_string(source, pos, end, src_len)
+        continue
+      pos += 1
+    return False
 
   def _walk_joined_strs(self, node):
     for child in ast.iter_child_nodes(node):

--- a/vermin/source_state.py
+++ b/vermin/source_state.py
@@ -52,6 +52,7 @@ class SourceState:
     self.fstrings = False
     self.fstrings_self_doc = False
     self.fstrings_pep701 = False
+    self.fstrings_await = False
     self.bool_const = False
     self.annotations = False
     self.var_annotations = False

--- a/vermin/source_state.py
+++ b/vermin/source_state.py
@@ -149,13 +149,7 @@ class SourceState:
     # Lines that should be ignored if they have the comment "novermin" or "novm".
     self.no_lines = set()
 
-    # Default to disabling fstring self-doc detection since the built-in AST cannot distinguish
-    # `f'{a=}'` from `f'a={a}'`, for instance, because it optimizes some information away. And this
-    # incorrectly marks some source code as using fstring self-doc when only using general fstring.
     self.fstring_self_doc_enabled = self.config.has_feature("fstring-self-doc")
-
-    # Default to disabling PEP 701 fstring detection since it requires source code heuristics to
-    # detect same-quote nesting and multi-line expressions in fstrings.
     self.fstrings_pep701_enabled = self.config.has_feature("fstring-pep701")
 
     # Default to disabling union types detection because it sometimes fails to report it correctly

--- a/vermin/source_state.py
+++ b/vermin/source_state.py
@@ -51,6 +51,7 @@ class SourceState:
     self.bytesv3 = False
     self.fstrings = False
     self.fstrings_self_doc = False
+    self.fstrings_pep701 = False
     self.bool_const = False
     self.annotations = False
     self.var_annotations = False
@@ -152,6 +153,10 @@ class SourceState:
     # `f'{a=}'` from `f'a={a}'`, for instance, because it optimizes some information away. And this
     # incorrectly marks some source code as using fstring self-doc when only using general fstring.
     self.fstring_self_doc_enabled = self.config.has_feature("fstring-self-doc")
+
+    # Default to disabling PEP 701 fstring detection since it requires source code heuristics to
+    # detect same-quote nesting and multi-line expressions in fstrings.
+    self.fstrings_pep701_enabled = self.config.has_feature("fstring-pep701")
 
     # Default to disabling union types detection because it sometimes fails to report it correctly
     # due to using heuristics.

--- a/vermin/source_visitor.py
+++ b/vermin/source_visitor.py
@@ -704,7 +704,7 @@ class SourceVisitor(ast.NodeVisitor):
 
     if self.__s.config.is_excluded_kwarg(function, keyword):
       self.__vvprint("Excluding kwarg: {}({})".format(function, keyword))
-      return False
+      return None
 
     fn_kw = (function, keyword)
     if fn_kw not in self.__s.kwargs:
@@ -1262,7 +1262,7 @@ class SourceVisitor(ast.NodeVisitor):
     self.generic_visit(node)
 
   def visit_keyword(self, node):
-    added = False
+    excluded = False
     for func_name in self.__s.function_name_stack:
       # kwarg related.
       exp_name = func_name.split(".")
@@ -1270,28 +1270,33 @@ class SourceVisitor(ast.NodeVisitor):
       # Check if function is imported from module.
       if func_name in self.__s.import_mem_mod:
         mod = self.__s.import_mem_mod[func_name]
-        added |= self.__add_kwargs(dotted_name([mod, func_name]), node.arg, self.__s.line)
+        excluded |= \
+          self.__add_kwargs(dotted_name([mod, func_name]), node.arg, self.__s.line) is None
 
       # When having "ElementTree.tostringlist", for instance, and include mapping "{'ElementTree':
       # 'xml.etree'}" then try piecing them together to form a match.
       elif exp_name[0] in self.__s.import_mem_mod:
         mod = self.__s.import_mem_mod[exp_name[0]]
-        added |= self.__add_kwargs(dotted_name([mod, func_name]), node.arg, self.__s.line)
+        excluded |= \
+          self.__add_kwargs(dotted_name([mod, func_name]), node.arg, self.__s.line) is None
 
       # Lookup indirect names via variables.
       elif exp_name[0] in self.__s.name_res:
         res = self.__s.name_res[exp_name[0]]
         if res in self.__s.import_mem_mod:
           mod = self.__s.import_mem_mod[res]
-          added |= self.__add_kwargs(dotted_name([mod, res, exp_name[1:]]), node.arg, self.__s.line)
+          excluded |= \
+            self.__add_kwargs(dotted_name([mod, res, exp_name[1:]]), node.arg,
+                              self.__s.line) is None
 
         # Try as FQN.
         else:
-          added |= self.__add_kwargs(dotted_name([res, exp_name[1:]]), node.arg, self.__s.line)
+          excluded |= \
+            self.__add_kwargs(dotted_name([res, exp_name[1:]]), node.arg, self.__s.line) is None
 
       # Only add direct function if not found via module/class/member.
       else:
-        added |= self.__add_kwargs(func_name, node.arg, self.__s.line)
+        excluded |= self.__add_kwargs(func_name, node.arg, self.__s.line) is None
 
       # A chained receiver, like `Path.cwd().exists(follow_symlinks=True)`, yields intermediate
       # call(s) in the name (`Path.cwd.exists`) that hide the real method being called. When the
@@ -1317,11 +1322,11 @@ class SourceVisitor(ast.NodeVisitor):
 
           collapsed_name = dotted_name(collapsed)
           if (collapsed_name, node.arg) in self.__s.kwargs_reqs_rules:
-            added |= self.__add_kwargs(collapsed_name, node.arg, self.__s.line)
+            excluded |= self.__add_kwargs(collapsed_name, node.arg, self.__s.line) is None
             break
 
-    # If not excluded or ignored then visit keyword values also.
-    if added:
+    # Visit keyword values unless the keyword rule was explicitly excluded.
+    if not excluded:
       self.generic_visit(node)
 
   def visit_Bytes(self, node):

--- a/vermin/source_visitor.py
+++ b/vermin/source_visitor.py
@@ -104,6 +104,9 @@ class SourceVisitor(ast.NodeVisitor):
   def fstrings_pep701(self):
     return self.__s.fstrings_pep701
 
+  def fstrings_await(self):
+    return self.__s.fstrings_await
+
   def bool_const(self):
     return self.__s.bool_const
 
@@ -377,6 +380,9 @@ class SourceVisitor(ast.NodeVisitor):
 
     if self.fstrings_pep701():
       mins = self.__add_versions_entity(mins, (None, (3, 12)), "f-strings (PEP 701)")
+
+    if self.fstrings_await():
+      mins = self.__add_versions_entity(mins, (None, (3, 7)), "`await` in f-string")
 
     if self.bool_const():  # pragma: no cover
       mins = self.__add_versions_entity(mins, ((2, 3), (3, 0)), "'bool' constant")
@@ -1479,7 +1485,26 @@ ast.Call(func=ast.Name)."""
         self.__s.fstrings_pep701 = True
         self.__vvprint("f-strings (PEP 701)", versions=[None, (3, 12)])
 
+    # `await` was only allowed within f-string expressions from 3.7.
+    if hasattr(node, "values") and self.__fstring_has_await(node):
+      self.__s.fstrings_await = True
+      self.__vvprint("`await` in f-string", versions=[None, (3, 7)])
+
     self.generic_visit(node)
+
+  def __fstring_has_await(self, node):
+    for value in node.values:
+      if isinstance(value, ast.FormattedValue) and self.__contains_await(value):
+        return True
+    return False
+
+  def __contains_await(self, node):
+    if isinstance(node, ast.Await):
+      return True
+    for child in ast.iter_child_nodes(node):
+      if self.__contains_await(child):
+        return True
+    return False
 
   # Mark variable names as aliases.
   def visit_Assign(self, node):

--- a/vermin/source_visitor.py
+++ b/vermin/source_visitor.py
@@ -101,6 +101,9 @@ class SourceVisitor(ast.NodeVisitor):
   def fstrings_self_doc(self):
     return self.__s.fstrings_self_doc
 
+  def fstrings_pep701(self):
+    return self.__s.fstrings_pep701
+
   def bool_const(self):
     return self.__s.bool_const
 
@@ -371,6 +374,9 @@ class SourceVisitor(ast.NodeVisitor):
 
     if self.fstrings_self_doc():  # pragma: no cover
       mins = self.__add_versions_entity(mins, (None, (3, 8)), "self-documenting f-strings")
+
+    if self.fstrings_pep701():  # pragma: no cover
+      mins = self.__add_versions_entity(mins, (None, (3, 12)), "f-strings (PEP 701)")
 
     if self.bool_const():  # pragma: no cover
       mins = self.__add_versions_entity(mins, ((2, 3), (3, 0)), "'bool' constant")
@@ -1450,228 +1456,6 @@ ast.Call(func=ast.Name)."""
     if is_ellipsis_node(node):
       self.visit_Ellipsis(node)
 
-  def __extract_fstring_value(self, node):  # pragma: no cover
-    value = []
-    is_call = False
-    for n in ast.walk(node):
-      if isinstance(n, ast.Name):
-        value.append(n.id)
-
-      elif hasattr(ast, "Constant") and isinstance(n, ast.Constant):
-        v = str(n.value)
-        if isinstance(n.value, str):
-          v = "\"{}\"".format(v)
-        value.append(v)
-
-      elif isinstance(n, ast.Add):
-        value.append("+")
-
-      elif isinstance(n, ast.Sub):
-        value.append("-")
-
-      elif isinstance(n, ast.Div):
-        value.append("/")
-
-      elif isinstance(n, ast.FloorDiv):
-        value.append("//")
-
-      elif isinstance(n, ast.Mult):
-        value.append("*")
-
-      elif hasattr(ast, "MatMult") and isinstance(n, ast.MatMult):
-        value.append("@")
-
-      elif isinstance(n, ast.Mod):
-        value.append("%")
-
-      elif isinstance(n, ast.Pow):
-        value.append("**")
-
-      elif isinstance(n, ast.BitXor):
-        value.append("^")
-
-      elif isinstance(n, ast.BitOr):
-        value.append("|")
-
-      elif isinstance(n, ast.BitAnd):
-        value.append("&")
-
-      elif isinstance(n, ast.Not):
-        value.append("not ")
-
-      elif isinstance(n, ast.USub):
-        value.append("-")
-
-      elif isinstance(n, ast.UAdd):
-        value.append("+")
-
-      elif isinstance(n, ast.Invert):
-        value.append("~")
-
-      elif isinstance(n, ast.LShift):
-        value.append("<<")
-
-      elif isinstance(n, ast.RShift):
-        value.append(">>")
-
-      elif isinstance(n, ast.In):
-        value.append("in ")
-
-      elif isinstance(n, ast.NotIn):
-        value.append("not in ")
-
-      elif isinstance(n, ast.Is):
-        value.append(" is ")
-
-      elif isinstance(n, ast.IsNot):
-        value.append(" is not ")
-
-      elif isinstance(n, ast.Or):
-        value.append(" or ")
-
-      elif isinstance(n, ast.And):
-        value.append(" and ")
-
-      elif isinstance(n, ast.Eq):
-        value.append(" == ")
-
-      elif isinstance(n, ast.NotEq):
-        value.append(" != ")
-
-      elif isinstance(n, ast.LtE):
-        value.append(" <= ")
-
-      elif isinstance(n, ast.GtE):
-        value.append(" >= ")
-
-      elif isinstance(n, ast.Gt):
-        value.append(" > ")
-
-      elif isinstance(n, ast.Lt):
-        value.append(" < ")
-
-      elif hasattr(ast, "comprehension") and isinstance(n, ast.comprehension):
-        target = self.__extract_fstring_value(n.target)
-        iter_ = self.__extract_fstring_value(n.iter)
-        value.append("{} in {}".format(target, iter_))
-        break
-
-      elif isinstance(n, ast.Attribute):
-        value += self.__get_attribute_name(n)
-        break
-
-      elif isinstance(n, ast.keyword):
-        val = self.__extract_fstring_value(n.value)
-        value.append("{}={}".format(n.arg, val))
-        break
-
-      elif isinstance(n, ast.Call):
-        is_call = True
-        if len(n.args) == 0 and len(n.keywords) == 0:
-          value.append("{}()".format(self.__extract_fstring_value(n.func)))
-          break
-
-      elif isinstance(n, ast.BinOp):
-        left = self.__extract_fstring_value(n.left)
-        op = self.__extract_fstring_value(n.op)
-        right = self.__extract_fstring_value(n.right)
-        value.append(left + op + right)
-        break
-
-      elif isinstance(n, ast.UnaryOp):
-        op = self.__extract_fstring_value(n.op)
-        operand = self.__extract_fstring_value(n.operand)
-        value.append(op + operand)
-        break
-
-      elif isinstance(n, ast.BoolOp):
-        op = self.__extract_fstring_value(n.op)
-        vals = [self.__extract_fstring_value(v) for v in n.values]
-        value.append(op.join(vals))
-        break
-
-      elif isinstance(n, ast.IfExp):
-        test = self.__extract_fstring_value(n.test)
-        body = self.__extract_fstring_value(n.body)
-        orelse = self.__extract_fstring_value(n.orelse)
-        value.append("{} if {} else {}".format(body, test, orelse))
-        break
-
-      elif isinstance(n, ast.Tuple):
-        elts = [self.__extract_fstring_value(elt) for elt in n.elts]
-        value.append("({})".format(",".join(elts)))
-        break
-
-      elif isinstance(n, ast.List):
-        elts = [self.__extract_fstring_value(elt) for elt in n.elts]
-        value.append("[{}]".format(",".join(elts)))
-        break
-
-      elif isinstance(n, ast.Set):
-        elts = [self.__extract_fstring_value(elt) for elt in n.elts]
-        value.append("{" + ",".join(elts) + "}")
-        break
-
-      elif isinstance(n, ast.Dict):
-        keys = [self.__extract_fstring_value(key) for key in n.keys]
-        vals = [self.__extract_fstring_value(val) for val in n.values]
-        kvs = ",".join(["{}:{}".format(k, v) for (k, v) in zip(keys, vals)])
-        value.append("{" + kvs + "}")
-        break
-
-      elif sys.version_info >= (3, 9) \
-           and isinstance(n, (ast.Constant, ast.Name, ast.Slice, ast.Tuple)):
-        # Check on slice indices like a[0] or a[i] or a[0:1] or a[(0,1)]
-        val = self.__extract_fstring_value(n)
-        value.append(val)
-        break
-      elif sys.version_info < (3, 9) and isinstance(n, ast.Index):
-        val = self.__extract_fstring_value(n.value)
-        value.append(val)
-        break
-
-      elif hasattr(ast, "ListComp") and isinstance(n, ast.ListComp):
-        elt = self.__extract_fstring_value(n.elt)
-        gens = [self.__extract_fstring_value(gen) for gen in n.generators]
-        value.append("[{} for {}]".format(elt, " ".join(gens)))
-        break
-
-      elif hasattr(ast, "SetComp") and isinstance(n, ast.SetComp):
-        elt = self.__extract_fstring_value(n.elt)
-        gens = [self.__extract_fstring_value(gen) for gen in n.generators]
-        value.append("{" + "{} for {}".format(elt, " ".join(gens)) + "}")
-        break
-
-      elif hasattr(ast, "DictComp") and isinstance(n, ast.DictComp):
-        key = self.__extract_fstring_value(n.key)
-        val = self.__extract_fstring_value(n.value)
-        gens = [self.__extract_fstring_value(gen) for gen in n.generators]
-        value.append("{" + "{}:{} for {}".format(key, val, " ".join(gens)) + "}")
-        break
-
-      elif hasattr(ast, "GeneratorExp") and isinstance(n, ast.GeneratorExp):
-        elt = self.__extract_fstring_value(n.elt)
-        gens = [self.__extract_fstring_value(gen) for gen in n.generators]
-        value.append("({} for {})".format(elt, " ".join(gens)))
-        break
-
-      elif isinstance(n, ast.Compare):
-        left = self.__extract_fstring_value(n.left)
-        ops = [self.__extract_fstring_value(op) for op in n.ops]
-        comps = [self.__extract_fstring_value(comp) for comp in n.comparators]
-        value.append(left + "".join(["{} {}".format(op, comp) for (op, comp) in zip(ops, comps)]))
-        break
-
-      elif isinstance(n, ast.Subscript):
-        val = self.__extract_fstring_value(n.value)
-        slice_ = self.__extract_fstring_value(n.slice)
-        value.append("{}[{}]".format(val, slice_))
-        break
-
-    if is_call:
-      return "(".join(value) + ")" * (len(value) - 1)  # "a(b(c()))"
-    return ".".join(value)  # "a" or "a.b"..
-
   def visit_JoinedStr(self, node):
     self.__s.fstrings = True
     self.__vvprint("f-strings", versions=[None, (3, 6)])
@@ -1681,6 +1465,14 @@ ast.Call(func=ast.Name)."""
       if self.__fstr.is_self_doc(node):
         self.__s.fstrings_self_doc = True
         self.__vvprint("self-documenting f-strings", versions=[None, (3, 8)])
+
+    # PEP 701 fstrings detection requires Python 3.12+ to parse the syntax in the first place, and
+    # avoids both false positives and false negatives.
+    if self.__s.fstrings_pep701_enabled and sys.version_info >= (3, 12) and \
+       hasattr(node, "values") and hasattr(node, "end_lineno"):  # pragma: no cover
+      if self.__fstr.pep701_violation(node) is not None:
+        self.__s.fstrings_pep701 = True
+        self.__vvprint("f-strings (PEP 701)", versions=[None, (3, 12)])
 
     self.generic_visit(node)
 

--- a/vermin/source_visitor.py
+++ b/vermin/source_visitor.py
@@ -372,10 +372,10 @@ class SourceVisitor(ast.NodeVisitor):
     if self.fstrings():
       mins = self.__add_versions_entity(mins, (None, (3, 6)), "f-strings")
 
-    if self.fstrings_self_doc():  # pragma: no cover
+    if self.fstrings_self_doc():
       mins = self.__add_versions_entity(mins, (None, (3, 8)), "self-documenting f-strings")
 
-    if self.fstrings_pep701():  # pragma: no cover
+    if self.fstrings_pep701():
       mins = self.__add_versions_entity(mins, (None, (3, 12)), "f-strings (PEP 701)")
 
     if self.bool_const():  # pragma: no cover
@@ -1466,7 +1466,7 @@ ast.Call(func=ast.Name)."""
     self.__vvprint("f-strings", versions=[None, (3, 6)])
 
     if self.__s.fstring_self_doc_enabled and hasattr(node, "values") and \
-       hasattr(node, "end_lineno"):  # pragma: no cover
+       hasattr(node, "end_lineno"):
       if self.__fstr.is_self_doc(node):
         self.__s.fstrings_self_doc = True
         self.__vvprint("self-documenting f-strings", versions=[None, (3, 8)])
@@ -1474,7 +1474,7 @@ ast.Call(func=ast.Name)."""
     # PEP 701 fstrings detection requires Python 3.12+ to parse the syntax in the first place, and
     # avoids both false positives and false negatives.
     if self.__s.fstrings_pep701_enabled and sys.version_info >= (3, 12) and \
-       hasattr(node, "values") and hasattr(node, "end_lineno"):  # pragma: no cover
+       hasattr(node, "values") and hasattr(node, "end_lineno"):
       if self.__fstr.pep701_violation(node) is not None:
         self.__s.fstrings_pep701 = True
         self.__vvprint("f-strings (PEP 701)", versions=[None, (3, 12)])

--- a/vermin/source_visitor.py
+++ b/vermin/source_visitor.py
@@ -4,12 +4,12 @@ from collections import deque
 import sys
 
 from .source_state import SourceState
+from .fstring_detector import FStringDetector
 from .rules import STRFTIME_REQS, BYTES_REQS, ARRAY_TYPECODE_REQS, CODECS_ERROR_HANDLERS, \
   CODECS_ERRORS_INDICES, CODECS_ENCODINGS, CODECS_ENCODINGS_INDICES, \
   BUILTIN_GENERIC_ANNOTATION_TYPES, DICT_UNION_SUPPORTED_TYPES, DICT_UNION_MERGE_SUPPORTED_TYPES, \
   DECORATOR_USER_FUNCTIONS
-from .utility import dotted_name, reverse_range, combine_versions, compare_requirements, \
-  remove_whitespace
+from .utility import dotted_name, reverse_range, combine_versions, compare_requirements
 
 STRFTIME_DIRECTIVE_REGEX = re.compile(r"%(?:[-\.\d#\s\+])*(\w)")
 BYTES_DIRECTIVE_REGEX = STRFTIME_DIRECTIVE_REGEX
@@ -57,11 +57,6 @@ def is_valid_star_unpack(node):
   return hasattr(ast, "Starred") and isinstance(node, ast.Starred) and\
     isinstance(node.ctx, ast.Load)
 
-def trim_fstring_value(value):  # pragma: no cover
-  # HACK: Since parentheses are stripped of the AST, we'll just remove all those deduced or directly
-  # available such that the self-doc f-strings can be compared.
-  return remove_whitespace(value, ["\\(", "\\)"])
-
 def assign_target_walk(node):
   """Walker used for determining assignment target nodes. It ignores all `ast.Subscript` and
 `ast.Attribute` nodes.
@@ -77,6 +72,7 @@ class SourceVisitor(ast.NodeVisitor):
   def __init__(self, config, path=None, source=None):
     super().__init__()
     self.__s = SourceState(config, path, source)
+    self.__fstr = FStringDetector(self.__s.source)
 
   def modules(self):
     return self.__s.modules
@@ -371,10 +367,10 @@ class SourceVisitor(ast.NodeVisitor):
       mins = self.__add_versions_entity(mins, ((2, 6), (3, 0)), "'bytes' type")
 
     if self.fstrings():
-      mins = self.__add_versions_entity(mins, (None, (3, 6)), "fstrings")
+      mins = self.__add_versions_entity(mins, (None, (3, 6)), "f-strings")
 
     if self.fstrings_self_doc():  # pragma: no cover
-      mins = self.__add_versions_entity(mins, (None, (3, 8)), "self-documenting fstrings")
+      mins = self.__add_versions_entity(mins, (None, (3, 8)), "self-documenting f-strings")
 
     if self.bool_const():  # pragma: no cover
       mins = self.__add_versions_entity(mins, ((2, 3), (3, 0)), "'bool' constant")
@@ -1679,24 +1675,12 @@ ast.Call(func=ast.Name)."""
   def visit_JoinedStr(self, node):
     self.__s.fstrings = True
     self.__vvprint("f-strings", versions=[None, (3, 6)])
-    if self.__s.fstring_self_doc_enabled and hasattr(node, "values"):  # pragma: no cover
-      total = len(node.values)
-      for i in range(total):
-        val = node.values[i]
-        # A self-referencing f-string will be at the end of the Constant, like "..stuff..expr=", and
-        # the next value will be a FormattedValue(value=..) with Names or nested Calls with Names
-        # inside, for instance.
-        if isinstance(val, ast.Constant) and hasattr(val, "value") and \
-           isinstance(val.value, str) and val.value.strip().endswith("=") and i + 1 < total:
-            next_val = node.values[i + 1]
-            if isinstance(next_val, ast.FormattedValue):
-              fstring_value =\
-                trim_fstring_value(self.__extract_fstring_value(next_val.value))
-              if len(fstring_value) > 0 and\
-                trim_fstring_value(val.value).endswith(fstring_value + "="):
-                  self.__s.fstrings_self_doc = True
-                  self.__vvprint("self-documenting fstrings", versions=[None, (3, 8)])
-                  break
+
+    if self.__s.fstring_self_doc_enabled and hasattr(node, "values") and \
+       hasattr(node, "end_lineno"):  # pragma: no cover
+      if self.__fstr.is_self_doc(node):
+        self.__s.fstrings_self_doc = True
+        self.__vvprint("self-documenting f-strings", versions=[None, (3, 8)])
 
     self.generic_visit(node)
 

--- a/vermin/utility.py
+++ b/vermin/utility.py
@@ -219,3 +219,38 @@ def compare_requirements(reqs, targets, ignore_exact=False):
         return False
   # all targets satisfied
   return True
+
+def split_lines(source):
+  """Splits source into lines on `\\n`, `\\r`, and `\\r\\n` (not vertical tabs or form feeds), and
+  returns the code-point start offset of each line: `(lines, offsets)` where `lines[i]` is the text
+  of line `i + 1` with its line terminator stripped and `offsets[i]` is its start offset in source.
+  """
+  lines = []
+  offsets = [0]
+  n = len(source)
+  prev = 0
+  i = 0
+  while i < n:
+    ch = source[i]
+    if ch == "\n":
+      i += 1
+    elif ch == "\r":
+      i += 1
+      if i < n and source[i] == "\n":
+        i += 1
+    else:
+      i += 1
+      continue
+    offsets.append(i)
+    seg = source[prev:i]
+    if seg.endswith("\r\n"):
+      seg = seg[:-2]
+    elif seg.endswith("\n") or seg.endswith("\r"):
+      seg = seg[:-1]
+    lines.append(seg)
+    prev = i
+  if prev < n:
+    lines.append(source[prev:])
+  if len(offsets) == len(lines):
+    offsets.append(n)
+  return lines, offsets


### PR DESCRIPTION
Fixes #39 (self-documenting f-strings) and #264 (PEP 701 f-strings).

`f'{a=}'` vs `f'a={a}'` and same-quote vs different-quote nesting look identical in the AST, so detection moves to a new `FStringDetector` that combines AST analysis with source code verification:
                                                                                                                                                  
- Self-doc f-strings (`f'{a=}'`, 3.8+), replacing the old conversion heuristic that produced many `!r` false positives.                      
- PEP 701 f-strings (3.12+): same-quote nesting, multi-line expressions, backslashes, comments, and quote-reusing literals.                  
- `await` in f-strings (3.7+).                                                                                                               

**Note:** Both f-string features are now enabled by default. Use `--no-feature` to disable. 